### PR TITLE
Ajuste na construção do elemento date da citação.

### DIFF
--- a/articlemeta/export_sci.py
+++ b/articlemeta/export_sci.py
@@ -97,11 +97,23 @@ class XMLCitation(object):
         def transform(self, data):
             raw, xml = data
 
-            year = ET.Element('year')
-            year.text = raw.date
-
             pdate = ET.Element('date')
+
+            if raw.date[8:10]:
+                day = ET.Element('day')
+                day.text = raw.date[8:10]
+                pdate.append(day)
+
+            if raw.date[5:7]:
+                month = ET.Element('month')
+                month.text = raw.date[5:7]
+                pdate.append(month)
+
+            year = ET.Element('year')
+            year.text = raw.date[0:4]
             pdate.append(year)
+
+
 
             xml.find('./element-citation').append(pdate)
 

--- a/tests/test_export_sci.py
+++ b/tests/test_export_sci.py
@@ -126,6 +126,46 @@ class XMLCitationTests(unittest.TestCase):
 
         self.assertEqual(u'2006', expected)
 
+    def test_xml_citation_date_with_year_and_month_pipe(self):
+
+        fakexylosearticle = Article({'article': {},
+                                     'title': {},
+                                     'citations': [{'v65': [{'_': '200604'}]}]}).citations[0]
+
+        pxml = ET.Element('ref')
+        pxml.append(ET.Element('element-citation'))
+
+        data = [fakexylosearticle, pxml]
+
+        raw, xml = self._xmlcitation.DatePipe().transform(data)
+
+        expected_year = xml.find('./element-citation/date/year').text
+        expected_month = xml.find('./element-citation/date/month').text
+
+        self.assertEqual(u'2006', expected_year)
+        self.assertEqual(u'04', expected_month)
+
+    def test_xml_citation_date_with_year_and_month_and_day_pipe(self):
+
+        fakexylosearticle = Article({'article': {},
+                                     'title': {},
+                                     'citations': [{'v65': [{'_': '20060430'}]}]}).citations[0]
+
+        pxml = ET.Element('ref')
+        pxml.append(ET.Element('element-citation'))
+
+        data = [fakexylosearticle, pxml]
+
+        raw, xml = self._xmlcitation.DatePipe().transform(data)
+
+        expected_year = xml.find('./element-citation/date/year').text
+        expected_month = xml.find('./element-citation/date/month').text
+        expected_day = xml.find('./element-citation/date/day').text
+
+        self.assertEqual(u'2006', expected_year)
+        self.assertEqual(u'04', expected_month)
+        self.assertEqual(u'30', expected_day)
+
     def test_xml_citation_date_without_data_pipe(self):
 
         fakexylosearticle = Article({'article': {},


### PR DESCRIPTION
Ajustando construção do elemento date de uma citação, os dados de dia, mês e ano agora ficam separados em seus respectivos elementos de acordo com o exigido no Schema.
#17
