### PR TITLE
forçar que a listagem dos endpoints history seja ordenada pelo campo: date #53

### DIFF
--- a/articlemeta/controller.py
+++ b/articlemeta/controller.py
@@ -332,7 +332,7 @@ class DataBroker(object):
             fltr['pid'] = pid
 
         total = self.db['historychanges_%s' % document_type].find(fltr).count()
-        data = self.db['historychanges_%s' % document_type].find(fltr).skip(offset).limit(limit)
+        data = self.db['historychanges_%s' % document_type].find(fltr).skip(offset).limit(limit).sort("date")
 
         meta = {
             'limit': limit,

--- a/articlemeta/decorators.py
+++ b/articlemeta/decorators.py
@@ -33,9 +33,9 @@ class LogHistoryChange(object):
     def __call__(self, fn):
         @wraps(fn)
         def decorated(*args, **kwargs):
-            # view func call
+            # decorated function call
             result = fn(*args, **kwargs)
-            # view func post-processing
+            # decorated function post-processing
             if self.event_type in ['update', 'delete', 'add'] and result:
                 pid = result.get('code', None)
                 collection = result.get('collection', None)

--- a/tests/fixtures/historylogs_article.json
+++ b/tests/fixtures/historylogs_article.json
@@ -14,7 +14,7 @@
         {
             "date": "2014-12-03T14:27:14.417061",
             "pid": "S1681-150X2014000300011",
-            "event": "post",
+            "event": "add",
             "collection": "test"
         },
         {
@@ -32,7 +32,7 @@
         {
             "date": "2014-12-03T14:27:14.417061",
             "pid": "S1681-150X2014000300011",
-            "event": "post",
+            "event": "add",
             "collection": "test"
         },
         {
@@ -50,7 +50,7 @@
         {
             "date": "2014-12-03T14:27:14.417061",
             "pid": "S1681-150X2014000300011",
-            "event": "post",
+            "event": "add",
             "collection": "test"
         },
         {
@@ -68,7 +68,7 @@
         {
             "date": "2014-12-03T14:27:14.417061",
             "pid": "S1681-150X2014000300011",
-            "event": "post",
+            "event": "add",
             "collection": "test"
         },
         {
@@ -86,7 +86,7 @@
         {
             "date": "2014-12-03T14:27:14.417061",
             "pid": "S1681-150X2014000300011",
-            "event": "post",
+            "event": "add",
             "collection": "test"
         },
         {
@@ -104,7 +104,7 @@
         {
             "date": "2014-12-03T14:27:14.417061",
             "pid": "S1681-150X2014000300011",
-            "event": "post",
+            "event": "add",
             "collection": "test"
         },
         {

--- a/tests/fixtures/historylogs_journal.json
+++ b/tests/fixtures/historylogs_journal.json
@@ -17,7 +17,7 @@
                 "1851-6114",
                 "0325-2957"
             ],
-            "event": "post",
+            "event": "add",
             "collection": "arg"
         },
         {
@@ -26,7 +26,7 @@
                 "1851-6114",
                 "0325-2957"
             ],
-            "event": "post",
+            "event": "add",
             "collection": "arg"
         },
         {
@@ -41,7 +41,7 @@
                 "1851-6114",
                 "0325-2957"
             ],
-            "event": "post",
+            "event": "add",
             "collection": "arg"
         },
         {

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -388,7 +388,7 @@ class ControllerTest(unittest.TestCase):
             databroker = mocker.mock()
             databroker['historychanges_%s' % document_type].find(ANY).count()
             mocker.result(historylogs['meta']['total'])
-            databroker['historychanges_%s' % document_type].find(ANY).skip(ANY).limit(ANY)
+            databroker['historychanges_%s' % document_type].find(ANY).skip(ANY).limit(ANY).sort("date")
             mocker.result(historylogs['objects'])
             mocker.replay()
 


### PR DESCRIPTION
Fixes: #53
- adiciono `sort` pelo campo date
- fix tests, para garantir que o `sort` é utilizado.
- ajustes nos fixtures, trocando `post` por `add` como é salvo agora.
