### PR TITLE
Suporte para o parametro limit nos querystrings #52

### DIFF
--- a/tests/test_view.py
+++ b/tests/test_view.py
@@ -13,3 +13,71 @@ class ViewsTest(unittest.TestCase):
 
     def tearDown(self):
         testing.tearDown()
+
+    def test_get_request_limit_param_by_default(self):
+        """
+        test default behavior of the helper function: _get_request_limit_param
+        - only positive limits are allowed
+        - if request.limit is greater than default_limit, will return the default limit (1000)
+        """
+        # set a list of tuples (limit requested, limit expected in response)
+        limits = [(1,1), (10, 10), (1000, 1000), (2000, 1000), (12000, 1000)]
+
+        for req_limit, resp_limit in limits:
+            request = testing.DummyRequest(params={'limit': req_limit})
+            result_limit = articlemeta._get_request_limit_param(request)
+            self.assertEqual(result_limit, resp_limit)
+
+    def test_get_request_limit_param_with_new_default_limit(self):
+        """
+        define new default limit, that will be the top value returned
+        """
+        new_default_limit = 200
+        # set a list of tuples (limit requested, limit expected in response)
+        limits = [
+            (1,1), (10, 10), (1000, new_default_limit),
+            (2000, new_default_limit), (12000, new_default_limit)
+        ]
+
+        for req_limit, resp_limit in limits:
+            request = testing.DummyRequest(params={'limit': req_limit})
+            result_limit = articlemeta._get_request_limit_param(request, default_limit=new_default_limit)
+            self.assertEqual(result_limit, resp_limit)
+
+    def test_get_request_limit_param_with_limit_zero_NOT_allowed(self):
+        """
+        By default the _get_request_limit_param will NOT accept request it limit <= 0
+        So here test that a BadRequestException is raised
+        """
+        limits = [(0,0), (-1, -1), (-1000, -1000)]
+
+        for req_limit, resp_limit in limits:
+            request = testing.DummyRequest(params={'limit': req_limit})
+            self.assertRaises(exc.HTTPBadRequest,
+                              articlemeta._get_request_limit_param,
+                              request)
+
+    def test_get_request_limit_param_with_limit_zero_allowed(self):
+        """
+        _get_request_limit_param can accept request it limit <= 0
+        So here test that and returns a valid number
+        """
+        limits = [(0,0), (-1, -1), (-1000, -1000)]
+
+        for req_limit, resp_limit in limits:
+            request = testing.DummyRequest(params={'limit': req_limit})
+            result_limit = articlemeta._get_request_limit_param(request, only_positive_limit=False)
+            self.assertEqual(result_limit, resp_limit)
+
+    def test_get_request_limit_param__can_ignore_default_limit(self):
+        """
+        In some case every requested limit, must be the returned,
+        even if is bigger than default_limit.
+        """
+        # set a list of tuples (limit requested, limit expected in response)
+        limits = [(1,1), (10, 10), (1000, 1000), (2000, 2000), (12000, 12000)]
+
+        for req_limit, resp_limit in limits:
+            request = testing.DummyRequest(params={'limit': req_limit})
+            result_limit = articlemeta._get_request_limit_param(request, force_max_limit_to_default=False)
+            self.assertEqual(result_limit, resp_limit)


### PR DESCRIPTION
Fixes: #52

Views que fazem queries na DB, como limite fixo:
- `*/identifiers/`
- `*/history/`

Agora se o parametro limit estiver presente na querystring dessas views:
- se não for possível converter para numero levanta um BadRequest (igual que offset quando é inválido)
- se for <= 0, levanta um BadRequest (igual que offset quando é inválido)
- se for maio do que máximo padrão, o limite aplicado é o máximo default (1000)

Se o parametro não estiver presente, o limite aplicado é o padrão (1000)
Existem parametros da função `_get_request_limit_param` que permite por exemplo aceitar o limit=0 ou ignorar o limit default (1000)
