### PR TITLE
Normalizando o unicode coletado pelo scraping.

### DIFF
--- a/articlemeta/export_crossref.py
+++ b/articlemeta/export_crossref.py
@@ -209,16 +209,16 @@ class XMLPubDatePipe(plumber.Pipe):
         else:
             el = ET.Element('publication_date', media_type='print')
 
-        # Day
-        if raw.publication_date[8:10]:
-            day = ET.Element('day')
-            day.text = raw.publication_date[8:10]
-            el.append(day)
         # Month
         if raw.publication_date[5:7]:
             month = ET.Element('month')
             month.text = raw.publication_date[5:7]
             el.append(month)
+        # Day
+        if raw.publication_date[8:10]:
+            day = ET.Element('day')
+            day.text = raw.publication_date[8:10]
+            el.append(day)
         # Year
         if raw.publication_date[0:4]:
             year = ET.Element('year')
@@ -356,29 +356,30 @@ class XMLArticleContributorsPipe(plumber.Pipe):
 
             author_index = [i.upper() for i in authors.get('xref', []) or []]
 
-            affs_list = []
-            for aff in raw.affiliations:
-                affiliation = ET.Element('affiliation')
-                if 'index' not in aff:
-                    continue
-                if aff['index'].upper() in author_index:
-                    aff_list = []
-                    if 'institution' in aff:
-                        aff_list.append(aff['institution'])
-                    if 'addr_line' in aff:
-                        aff_list.append(aff['addr_line'])
-                    if 'country' in aff:
-                        aff_list.append(aff['country'])
-
-                    aff_info = ',  '.join(aff_list)
-                    if len(aff_info.strip()) == 0:
+            if raw.affiliations:
+                affs_list = []
+                for aff in raw.affiliations:
+                    affiliation = ET.Element('affiliation')
+                    if 'index' not in aff:
                         continue
-                    affs_list.append(aff_info)
+                    if aff['index'].upper() in author_index:
+                        aff_list = []
+                        if 'institution' in aff:
+                            aff_list.append(aff['institution'])
+                        if 'addr_line' in aff:
+                            aff_list.append(aff['addr_line'])
+                        if 'country' in aff:
+                            aff_list.append(aff['country'])
 
-            affs = '; '.join(affs_list)
-            if len(affs) > 0:
-                affiliation.text = affs
-                author.append(affiliation)
+                        aff_info = ',  '.join(aff_list)
+                        if len(aff_info.strip()) == 0:
+                            continue
+                        affs_list.append(aff_info)
+
+                affs = '; '.join(affs_list)
+                if len(affs) > 0:
+                    affiliation.text = affs
+                    author.append(affiliation)
 
         xml.find('./body/journal/journal_article').append(el)
 
@@ -425,16 +426,16 @@ class XMLArticlePubDatePipe(plumber.Pipe):
         el = ET.Element('publication_date')
         el.set('media_type', "print")
 
-        # Day
-        if raw.publication_date[8:10]:
-            day = ET.Element('day')
-            day.text = raw.publication_date[8:10]
-            el.append(day)
         # Month
         if raw.publication_date[5:7]:
             month = ET.Element('month')
             month.text = raw.publication_date[5:7]
             el.append(month)
+        # Day
+        if raw.publication_date[8:10]:
+            day = ET.Element('day')
+            day.text = raw.publication_date[8:10]
+            el.append(day)
         # Year
         if raw.publication_date[0:4]:
             year = ET.Element('year')

--- a/processing/load_body.py
+++ b/processing/load_body.py
@@ -139,9 +139,15 @@ def do_request(url, json=True):
 
 
 def scrap_body(data, language):
+    '''
+    Function to scrap article by URL and slice the important content.
 
-    # html_parser = HTMLParser.HTMLParser()
-    # unescaped = html_parser.unescape(data)
+    Params:
+    :param data: bytes, encoded by source
+    :param language: str [en, es, pt, ...]
+
+    Return the unicode of the body encoded by etree.tostring line 178
+    '''
 
     encoding = chardet.detect(data)['encoding']
 

--- a/processing/load_body.py
+++ b/processing/load_body.py
@@ -11,13 +11,13 @@ import logging
 import logging.config
 from datetime import datetime, timedelta
 
+import chardet
 import requests
 from lxml import etree
 from io import StringIO
 
 from pymongo import MongoClient
 from xylose.scielodocument import Article
-from articlemeta import utils
 
 logger = logging.getLogger(__name__)
 SENTRY_DSN = os.environ.get('SENTRY_DSN', None)
@@ -72,7 +72,7 @@ REMOVE_LINKS_REGEX = re.compile(r'\[.<a href="javascript\:void\(0\);".*?>Links</
 try:
     articlemeta_db = MongoClient(MONGODB_HOST)['articlemeta']
 except:
-    logging.error('Fail to connect to (%s)', settings['app:main']['mongo_uri'])
+    logging.error('Fail to connect to (%s)', MONGODB_HOST)
 
 
 def collections_acronym():
@@ -95,7 +95,7 @@ def load_documents(collection, all_records=False):
         'collection': collection
     }
 
-    if all_records == False:
+    if not all_records:
         fltr['body'] = {'$exists': 0}
 
     documents = articlemeta_db['articles'].find(
@@ -142,6 +142,13 @@ def scrap_body(data, language):
 
     # html_parser = HTMLParser.HTMLParser()
     # unescaped = html_parser.unescape(data)
+
+    encoding = chardet.detect(data)['encoding']
+
+    #  IMPORTANTE: Nesse trecho estamos decodificando para o encoding descoberto
+    #  pelo chardet e substituindo os caracteres que não foram encotrados no
+    #  encoding por código unicode.
+    data = data.decode(encoding, 'replace')
 
     data = ' '.join([i.strip() for i in data.split('\n')])
 

--- a/processing/load_body.py
+++ b/processing/load_body.py
@@ -135,7 +135,7 @@ def do_request(url, json=True):
         if json:
             return document.json()
         else:
-            return document.text
+            return document.content
 
 
 def scrap_body(data, language):

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,8 @@ requires = [
     'thriftpy==0.3.1',
     'thriftpywrap',
     'xylose==1.18.6',
-    'raven'
+    'raven',
+    'chardet'
     ]
 
 test_requires = ['mocker']

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ test_requires = ['mocker']
 
 setup(
     name="articlemeta",
-    version='1.29.24',
+    version='1.29.25',
     description="A SciELO API to load SciELO Articles metadata",
     author="SciELO",
     author_email="scielo-dev@googlegroups.com",

--- a/tests/test_export_crossref.py
+++ b/tests/test_export_crossref.py
@@ -414,28 +414,6 @@ class ExportTests(unittest.TestCase):
 
         self.assertEqual(b'<doi_batch><body><journal><journal_article publication_type="full_text"><publisher_item><identifier id_type="pii">S0034-89102010000400007</identifier></publisher_item></journal_article></journal></body></doi_batch>', ET.tostring(xml))
 
-    def test_article_pid_element(self):
-
-        xmlcrossref = ET.Element('doi_batch')
-
-        journal_article = ET.Element('journal_article')
-        journal_article.set('publication_type', 'full_text')
-
-        journal = ET.Element('journal')
-        journal.append(journal_article)
-
-        body = ET.Element('body')
-        body.append(journal)
-
-        xmlcrossref.append(body)
-
-        data = [self._article_meta, xmlcrossref]
-
-        xmlcrossref = export_crossref.XMLDOIDataPipe()
-        raw, xml = xmlcrossref.transform(data)
-
-        self.assertEqual(b'<doi_batch><body><journal><journal_article publication_type="full_text"><doi_data><doi>10.1590/S0034-89102010000400007</doi><resource>http://www.scielo.br/scielo.php?script=sci_arttext&amp;pid=S0034-89102010000400007&amp;lng=pt&amp;tlng=pt</resource></doi_data></journal_article></journal></body></doi_batch>', ET.tostring(xml))
-
     def test_xmlclose_pipe(self):
 
         pxml = ET.Element('doi_batch')

--- a/tests/test_load_body.py
+++ b/tests/test_load_body.py
@@ -12,10 +12,9 @@ class LoadLicensesTest(unittest.TestCase):
 
         data = u"""<html><header></header><body><div class="content"><div class="index,en"><div class="title">Crazy <i>Title</i></div><p>Crazy Body</p><p>Really Crazy Body</p></div></div></body></html>"""
 
-        result = load_body.scrap_body(data, 'en')
+        result = load_body.scrap_body(data.encode('utf-8'), 'en')
 
         self.assertEqual(result, '<div class="title">Crazy <i>Title</i></div><p>Crazy Body</p><p>Really Crazy Body</p>')
-
 
     def test_regex_remove_links1(self):
         import re
@@ -79,7 +78,7 @@ class LoadLicensesTest(unittest.TestCase):
           </html>
           """
 
-        result = load_body.scrap_body(data, 'en')
+        result = load_body.scrap_body(data.encode('utf-8'), 'en')
 
         self.assertEqual(result, '<div class="title">Crazy <i>Title</i></div> <p>Crazy Body</p> <p>Really Crazy Body</p>')
 
@@ -87,7 +86,7 @@ class LoadLicensesTest(unittest.TestCase):
 
         data = u"""<html><header></header><body><div class="content"><div class="index,en"><div class="title">Crazy <i>Title</i></div><p>Crazy Body</p><p>Really Crazy Body</p></div></div></body></html>"""
 
-        result = load_body.scrap_body(data, 'pt')
+        result = load_body.scrap_body(data.encode('utf-8'), 'pt')
 
         self.assertEqual(result, None)
 
@@ -95,14 +94,14 @@ class LoadLicensesTest(unittest.TestCase):
 
         data = u"""<html><header></header><body><div class="content"></div></body></html>"""
 
-        result = load_body.scrap_body(data, 'pt')
+        result = load_body.scrap_body(data.encode('utf-8'), 'pt')
 
         self.assertEqual(result, None)
 
     def test_body_sample_1(self):
-        data = ' '.join([i.strip() for i in codecs.open(os.path.dirname(__file__)+'/fixtures/body_sample_1.html', 'r', encoding='utf-8').readlines()])
+        data = codecs.open(os.path.dirname(__file__)+'/fixtures/body_sample_1.html', 'r', encoding='utf-8').read()
 
-        result = load_body.scrap_body(data, 'pt')
+        result = load_body.scrap_body(data.encode('utf-8'), 'pt')
 
         # Text on the begining of the document
         self.assertTrue(u'On the one pot syntheses' in result)
@@ -110,9 +109,9 @@ class LoadLicensesTest(unittest.TestCase):
         self.assertTrue(u'Web Release Date: November 26, 2009' in result)
 
     def test_body_sample_2(self):
-        data = ' '.join([i.strip() for i in codecs.open(os.path.dirname(__file__)+'/fixtures/body_sample_2.html', 'r', encoding='utf-8').readlines()])
-      
-        result = load_body.scrap_body(data, 'pt')
+        data = codecs.open(os.path.dirname(__file__)+'/fixtures/body_sample_2.html', 'r', encoding='utf-8').read()
+
+        result = load_body.scrap_body(data.encode('utf-8'), 'pt')
 
         # Text on the begining of the document
         self.assertTrue(u'meio para isolamento de' in result)
@@ -120,9 +119,9 @@ class LoadLicensesTest(unittest.TestCase):
         self.assertTrue(u'Recebido    para publicação em 31-7-1967' in result)
 
     def test_body_sample_3(self):
-        data = ' '.join([i.strip() for i in codecs.open(os.path.dirname(__file__)+'/fixtures/body_sample_3.html', 'r', encoding='utf-8').readlines()])
-      
-        result = load_body.scrap_body(data, 'pt')
+        data = codecs.open(os.path.dirname(__file__)+'/fixtures/body_sample_3.html', 'r', encoding='utf-8').read()
+
+        result = load_body.scrap_body(data.encode('utf-8'), 'pt')
 
         # Text on the begining of the document
         self.assertTrue(u'A TRIBUTAÇÃO NA PRODUÇÃO DE CARVÃO VEGETAL' in result)
@@ -130,9 +129,9 @@ class LoadLicensesTest(unittest.TestCase):
         self.assertTrue(u'Recebido: 03 de Fevereiro de 2012; Aceito: 14 de Abril de 2014' in result)
 
     def test_body_sample_4(self):
-        data = ' '.join([i.strip() for i in codecs.open(os.path.dirname(__file__)+'/fixtures/body_sample_4.html', 'r', encoding='utf-8').readlines()])
-          
-        result = load_body.scrap_body(data, 'pt')
+        data = codecs.open(os.path.dirname(__file__)+'/fixtures/body_sample_4.html', 'r', encoding='utf-8').read()
+
+        result = load_body.scrap_body(data.encode('utf-8'), 'pt')
 
         # Text on the begining of the document
         self.assertTrue(u'Aquarelas de um Brasil' in result)
@@ -140,9 +139,9 @@ class LoadLicensesTest(unittest.TestCase):
         self.assertTrue(u'São Paulo, Companhia das Letras.' in result)
 
     def test_body_sample_5(self):
-        data = ' '.join([i.strip() for i in codecs.open(os.path.dirname(__file__)+'/fixtures/body_sample_5.html', 'r', encoding='utf-8').readlines()])
-      
-        result = load_body.scrap_body(data, 'pt')
+        data = codecs.open(os.path.dirname(__file__)+'/fixtures/body_sample_5.html', 'r', encoding='utf-8').read()
+
+        result = load_body.scrap_body(data.encode('utf-8'), 'pt')
 
         # Text on the begining of the document
         self.assertTrue(u'Molestia de Carlos Chagas' in result)
@@ -150,20 +149,19 @@ class LoadLicensesTest(unittest.TestCase):
         self.assertTrue(u'Full text available only in PDF format' in result)
 
     def test_body_sample_6(self):
-        data = ' '.join([i.strip() for i in codecs.open(os.path.dirname(__file__)+'/fixtures/body_sample_6.html', 'r', encoding='utf-8').readlines()])
-      
-        result = load_body.scrap_body(data, 'pt')
+        data = codecs.open(os.path.dirname(__file__)+'/fixtures/body_sample_6.html', 'r', encoding='utf-8').read()
+
+        result = load_body.scrap_body(data.encode('utf-8'), 'pt')
 
         # Text on the begining of the document
         self.assertTrue(u'Editorial' in result)
         # Text on the end of the document
         self.assertTrue(u'Boa leitura!' in result)
 
-
     def test_body_sample_7(self):
-        data = ' '.join([i.strip() for i in codecs.open(os.path.dirname(__file__)+'/fixtures/body_sample_7.html', 'r', encoding='utf-8').readlines()])
+        data = codecs.open(os.path.dirname(__file__)+'/fixtures/body_sample_7.html', 'r', encoding='utf-8').read()
 
-        result = load_body.scrap_body(data, 'en')
+        result = load_body.scrap_body(data.encode('utf-8'), 'en')
 
         # Text on the begining of the document
         self.assertTrue(u'caso da bacia    do Amazonas' in result)


### PR DESCRIPTION
@fabiobatalha 

por gentileza poderia aplicar esse ajuste e rodar o load_body.py somente para o ISSN: 1135-5727 (Revista Espanhola de Saúde Pública)

