### PR TITLE
Parte 1 da refatoração do módulo controller.py.

### DIFF
--- a/articlemeta/controller.py
+++ b/articlemeta/controller.py
@@ -139,50 +139,6 @@ def get_dbconn(db_dsn):
     return db
 
 
-def check_article_meta(metadata):
-    """Enriquece e normaliza itens do dicionário ``metadata``, que representa
-    metadados de um artigo.
-
-    A estrutura de ``metadata`` é a mesma retornada pelo formato JSON, do
-    ``articlemeta.scielo.org``, conforme exemplo:
-    https://gist.github.com/gustavofonseca/2b970721e587fe639b7ccffd5ea9fc96
-    """
-    metadata_copy = metadata.copy()
-    article = Article(metadata_copy)
-
-    issns = set(
-        [
-            article.journal.any_issn(priority=u'electronic'),
-            article.journal.any_issn(priority=u'print'),
-            article.journal.scielo_issn
-        ]
-    )
-
-    metadata_copy['code'] = article.publisher_id
-    metadata_copy['code_issue'] = article.publisher_id[1:18]
-    metadata_copy['code_title'] = list(issns)
-    metadata_copy['collection'] = article.collection_acronym
-    metadata_copy['document_type'] = article.document_type
-    metadata_copy['publication_year'] = article.publication_date[0:4]
-    metadata_copy['publication_date'] = article.publication_date
-    metadata_copy['validated_scielo'] = 'False'
-    metadata_copy['validated_wos'] = 'False'
-    metadata_copy['sent_wos'] = 'False'
-    metadata_copy['applicable'] = 'False'
-    metadata_copy['version'] = article.data_model_version
-
-    if article.doi:
-        metadata_copy['doi'] = article.doi.upper()
-
-    if not isinstance(article.data['article']['processing_date'], datetime):
-        try:
-            metadata_copy['processing_date'] = datetime.strptime(article.data['article']['processing_date'], '%Y-%m-%d')
-        except:
-            metadata_copy['processing_date'] = datetime.now()
-
-    return metadata_copy
-
-
 class IssueMeta:
     def __init__(self, db, journalmeta):
         self.db = db
@@ -600,6 +556,397 @@ class JournalMeta:
         return False
 
 
+class ArticleMeta:
+    def __init__(self, db, journalmeta, issuemeta):
+        self.db = db
+        self.journalmeta = journalmeta
+        self.issuemeta = issuemeta
+
+    def check(self, metadata):
+        """Enriquece e normaliza itens do dicionário ``metadata``, que representa
+        metadados de um artigo.
+
+        A estrutura de ``metadata`` é a mesma retornada pelo formato JSON, do
+        ``articlemeta.scielo.org``, conforme exemplo:
+        https://gist.github.com/gustavofonseca/2b970721e587fe639b7ccffd5ea9fc96
+        """
+        metadata_copy = metadata.copy()
+        article = Article(metadata_copy)
+
+        issns = set(
+            [
+                article.journal.any_issn(priority=u'electronic'),
+                article.journal.any_issn(priority=u'print'),
+                article.journal.scielo_issn
+            ]
+        )
+
+        metadata_copy['code'] = article.publisher_id
+        metadata_copy['code_issue'] = article.publisher_id[1:18]
+        metadata_copy['code_title'] = list(issns)
+        metadata_copy['collection'] = article.collection_acronym
+        metadata_copy['document_type'] = article.document_type
+        metadata_copy['publication_year'] = article.publication_date[0:4]
+        metadata_copy['publication_date'] = article.publication_date
+        metadata_copy['validated_scielo'] = 'False'
+        metadata_copy['validated_wos'] = 'False'
+        metadata_copy['sent_wos'] = 'False'
+        metadata_copy['applicable'] = 'False'
+        metadata_copy['version'] = article.data_model_version
+
+        if article.doi:
+            metadata_copy['doi'] = article.doi.upper()
+
+        if not isinstance(article.data['article']['processing_date'], datetime):
+            try:
+                metadata_copy['processing_date'] = datetime.strptime(article.data['article']['processing_date'], '%Y-%m-%d')
+            except:
+                metadata_copy['processing_date'] = datetime.now()
+
+        return metadata_copy
+
+    def identifiers(self, collection=None, issn=None, from_date='1500-01-01',
+            until_date=None, limit=LIMIT, offset=0, extra_filter=None):
+        """Lista os códigos identificadores dos artigos. A listagem pode ser
+        completa, por coleção, por ISSN ou por intervalo da data de processamento.
+        """
+        if offset < 0:
+            offset = 0
+
+        if limit < 0:
+            limit = LIMIT
+
+        fltr = {}
+        fltr['processing_date'] = get_date_range_filter(from_date, until_date)
+
+        if collection:
+            fltr['collection'] = collection
+
+        if issn:
+            fltr['code_title'] = issn
+
+        if extra_filter:
+            fltr.update(json.loads(extra_filter))
+
+        total = self.db.find(fltr).count()
+        data = self.db.find(fltr, {
+            'code': 1,
+            'collection': 1,
+            'processing_date': 1,
+            'aid': 1,
+            'doi': 1}).sort('processing_date').skip(offset).limit(limit)
+
+        meta = {
+            'limit': limit,
+            'offset': offset,
+            'filter': fltr,
+            'total': total
+        }
+
+        result = {'meta': meta, 'objects': []}
+        for i in data:
+            rec = {
+                'code': i['code'],
+                'collection': i['collection'],
+                'processing_date': i['processing_date']
+            }
+            if 'aid' in i:
+                rec['aid'] = i['aid']
+
+            if 'doi' in i:
+                rec['doi'] = i['doi']
+
+            result['objects'].append(dates_to_string(rec))
+
+        result['meta']['filter'] = dates_to_string(result['meta']['filter'])
+
+        return result
+
+    def get(self, code, collection=None, replace_journal_metadata=False, body=False):
+        """Obtém um artigo de código identificador ``code``. Opcionalmente,
+        um acrônimo de coleção pode ser passado por meio do arg ``collection``
+        para especializar a busca. O código identificador poderá ser: o código
+        de fato, o doi ou o aid do artigo.
+
+        O arg ``replace_journal_metadata`` faz com que o resultado da
+        consulta contenha a versão mais atualizada dos metadados do periódico.
+        Os metadados do fascículo são sempre atualizados.
+
+        Retorna um dicionário ou None.
+        """
+        fltr = {'$or': [{'code': code}, {'doi': code}, {'aid': code}]}
+        if collection:
+            fltr['collection'] = collection
+
+        fields = None
+
+        if not body:
+            fields = {'body': 0}
+
+        if fields:
+            data = self.db.find_one(fltr, fields)
+        else:
+            data = self.db.find_one(fltr)
+
+        if not data:
+            return None
+
+        if replace_journal_metadata is True:
+            journal = self.journalmeta.get(collection=collection,
+                    issn=data['title']['v400'][0]['_'])
+
+            if journal and len(journal) != 0:
+                data['title'] = journal[0]
+
+        issue = self.issuemeta.get(collection=collection, code=data['code'][1:18])
+
+        if issue:
+            data['issue'] = issue
+            if 'title' in data['issue']:
+                del(data['issue']['title'])
+
+        del(data['_id'])
+
+        return dates_to_string(data)
+
+    def get_articles_full(self, collection=None, issn=None,
+            from_date='1500-01-01', until_date=None, limit=100, offset=0,
+            extra_filter=None, replace_journal_metadata=False, body=False):
+        """Obtém uma lista dos artigos, que pode ser geral, por coleção,
+        por periódico ou intervalo de data de publicação. Há ainda a
+        possibilidade de usar filtros adhoc por meio de consultas diretas ao
+        MongoDB com o arg ``extra_filter`` (alto acoplamento; não recomendado).
+
+        O arg ``replace_journal_metadata`` faz com que o resultado da
+        consulta contenha a versão mais atualizada dos metadados do periódico.
+        Os metadados do fascículo são sempre atualizados.
+        """
+        if offset < 0:
+            offset = 0
+
+        if limit < 0:
+            limit = 100
+
+        fltr = {}
+        fltr['processing_date'] = get_date_range_filter(from_date, until_date)
+
+        if collection:
+            fltr['collection'] = collection
+
+        if issn:
+            fltr['code_title'] = issn
+
+        if extra_filter:
+            fltr.update(json.loads(extra_filter))
+
+        content = {
+            '_id': 0
+        }
+
+        if body is False:
+            content['body'] = 0
+
+        total = self.db.find(fltr).count()
+        data = self.db.find(fltr, content).sort(
+                'processing_date').skip(offset).limit(limit)
+
+        meta = {
+            'limit': limit,
+            'offset': offset,
+            'filter': fltr,
+            'total': total
+        }
+
+        result = {'meta': meta, 'objects': []}
+        for article in data:
+            if replace_journal_metadata:
+                journal = self.journalmeta.get(collection=collection,
+                        issn=article['title']['v400'][0]['_'])
+
+                if journal and len(journal) == 1:
+                    article['title'] = journal[0]
+
+            issue = self.issuemeta.get(collection=collection,
+                    code=article['code_issue'])
+
+            if issue:
+                article['issue'] = issue
+
+            result['objects'].append(dates_to_string(article))
+
+        result['meta']['filter'] = dates_to_string(result['meta']['filter'])
+
+        return result
+
+    def exists(self, code, collection=None):
+        """Se o artigo de código ``code`` existe. A consulta pode ser
+        realizada no contexto global ou de coleção.
+        """
+        fltr = {'code': code}
+        if collection:
+            fltr['collection'] = collection
+
+        if self.db.find(fltr).count() >= 1:
+            return True
+
+        return False
+
+    def delete(self, code, collection=None):
+        """Remove o artigo de código igual a ``code``, da coleção
+        ``collection``.
+
+        Retorna um dicionário na forma: 
+
+        .. code-block:: python
+
+            {'code': '0104-32692015000200008', 'collection': 'scl', 'deleted_count': 1}
+        """
+        fltr = {'code': code}
+        if collection:
+            fltr['collection'] = collection
+
+        deleted = self.db.delete_one(fltr)
+
+        fltr['code'] = code
+        fltr['deleted_count'] = deleted.deleted_count
+
+        return fltr
+
+    def add(self, metadata):
+        """Registra o artigo representado por ``metadata``.
+
+        Retorna uma cópia enriquecida do dicionário ``metadata``, com o
+        acréscimo da chave ``created_at``.
+        """
+        article = self.check(metadata)
+
+        if not article:
+            return None
+
+        if self.exists(article['code'], article['collection']):
+            return self.update(article)
+
+        article['created_at'] = article['processing_date']
+
+        self.db.update_one(
+            {'code': article['code'], 'collection': article['collection']},
+            {'$set': article},
+            upsert=True
+        )
+
+        return dates_to_string(article)
+
+    def update(self, metadata):
+        """Atualiza o registro do artigo representado por ``metadata``.
+
+        Retorna uma cópia enriquecida do dicionário ``metadata``, com o
+        acréscimo da chave ``updated_at``.
+        """
+        article = self.check(metadata)
+
+        if not article:
+            return None
+
+        article['updated_at'] = datetime.now()
+
+        self.db.update_one(
+            {'code': article['code'], 'collection': article['collection']},
+            {'$set': article},
+            upsert=True
+        )
+
+        return dates_to_string(article)
+
+    def identifiers_press_release(self, collection=None, issn=None,
+            from_date='1500-01-01', until_date=None, limit=LIMIT, offset=0):
+        if offset < 0:
+            offset = 0
+
+        if limit < 0:
+            limit = LIMIT
+
+        fltr = {}
+        fltr['processing_date'] = get_date_range_filter(from_date, until_date)
+
+        fltr['document_type'] = u'press-release'
+
+        if collection:
+            fltr['collection'] = collection
+
+        if issn:
+            fltr['code_title'] = issn
+
+        total = self.db.find(fltr).count()
+        data = self.db.find(fltr, {
+            'code': 1,
+            'collection': 1,
+            'processing_date': 1,
+            'aid': 1,
+            'doi': 1}).sort('processing_date').skip(offset).limit(limit)
+
+        meta = {
+            'limit': limit,
+            'offset': offset,
+            'filter': fltr,
+            'total': total
+        }
+
+        result = {'meta': meta, 'objects': []}
+        for i in data:
+            rec = {
+                'code': i['code'],
+                'collection': i['collection'],
+                'processing_date': i['processing_date']
+            }
+            if 'aid' in i:
+                rec['aid'] = i['aid']
+
+            if 'doi' in i:
+                rec['doi'] = i['doi']
+
+            result['objects'].append(dates_to_string(rec))
+
+        result['meta']['filter'] = dates_to_string(result['meta']['filter'])
+
+        return result
+
+    def set_doaj_id(self, code, collection, doaj_id):
+        fltr = {'code': code}
+        if collection:
+            fltr['collection'] = collection
+
+        self.db.update_one(fltr, {'$set': {'doaj_id': str(doaj_id)}})
+
+    def set_aid(self, code, collection, aid):
+        fltr = {'code': code}
+        if collection:
+            fltr['collection'] = collection
+
+        self.db.update_one(fltr, {'$set': {'aid': str(aid)}})
+
+
+class CollectionMeta:
+    def __init__(self, db):
+        self.db = db
+
+    def identifiers(self):
+        """Lista os códigos identificadores das coleções.
+        """
+        data = self.db.find({}, {'_id': 0})
+        if not data:
+            return None
+
+        return [i for i in data]
+
+    def get(self, collection):
+        """Obtém uma coleção de código identificador ``code``.
+
+        Retorna um dicionário ou None.
+        """
+        fltr = {'code': collection}
+        return self.db.find_one(fltr, {'_id': 0})
+
+
 class DataBroker(object):
     _dbconn_cache = {}
 
@@ -607,6 +954,9 @@ class DataBroker(object):
         self.db = databroker
         self.journalmeta = JournalMeta(self.db['journals'])
         self.issuemeta = IssueMeta(self.db['issues'], self.journalmeta)
+        self.articlemeta = ArticleMeta(self.db['articles'], self.journalmeta,
+                self.issuemeta)
+        self.collectionmeta = CollectionMeta(self.db['collections'])
 
     @classmethod
     def from_dsn(cls, db_dsn, reuse_dbconn=False):
@@ -698,19 +1048,10 @@ class DataBroker(object):
         return self.journalmeta.update(metadata)
 
     def identifiers_collection(self):
-
-        data = self.db['collections'].find({}, {'_id': 0})
-
-        if not data:
-            return None
-
-        return [i for i in data]
+        return self.collectionmeta.identifiers()
 
     def get_collection(self, collection):
-
-        fltr = {'code': collection}
-
-        return self.db['collections'].find_one(fltr, {'_id': 0})
+        return self.collectionmeta.get(collection=collection)
 
     def collection(self, collection=None):
         """
@@ -787,59 +1128,9 @@ class DataBroker(object):
                             limit=LIMIT,
                             offset=0,
                             extra_filter=None):
-
-        if offset < 0:
-            offset = 0
-
-        if limit < 0:
-            limit = LIMIT
-
-        fltr = {}
-        fltr['processing_date'] = get_date_range_filter(from_date, until_date)
-
-        if collection:
-            fltr['collection'] = collection
-
-        if issn:
-            fltr['code_title'] = issn
-
-        if extra_filter:
-            fltr.update(json.loads(extra_filter))
-
-        total = self.db['articles'].find(fltr).count()
-        data = self.db['articles'].find(fltr, {
-            'code': 1,
-            'collection': 1,
-            'processing_date': 1,
-            'aid': 1,
-            'doi': 1}
-        ).sort('processing_date').skip(offset).limit(limit)
-
-        meta = {
-            'limit': limit,
-            'offset': offset,
-            'filter': fltr,
-            'total': total
-        }
-
-        result = {'meta': meta, 'objects': []}
-        for i in data:
-            rec = {
-                'code': i['code'],
-                'collection': i['collection'],
-                'processing_date': i['processing_date']
-            }
-            if 'aid' in i:
-                rec['aid'] = i['aid']
-
-            if 'doi' in i:
-                rec['doi'] = i['doi']
-
-            result['objects'].append(dates_to_string(rec))
-
-        result['meta']['filter'] = dates_to_string(result['meta']['filter'])
-
-        return result
+        return self.articlemeta.identifiers(collection=collection, issn=issn,
+                from_date=from_date, until_date=until_date, limit=limit,
+                offset=offset, extra_filter=extra_filter)
 
     def identifiers_press_release(self,
                                   collection=None,
@@ -848,60 +1139,12 @@ class DataBroker(object):
                                   until_date=None,
                                   limit=LIMIT,
                                   offset=0):
+        return self.articlemeta.identifiers_press_release(collection=collection,
+                issn=issn, from_date=from_date, until_date=until_date,
+                limit=limit, offset=offset)
 
-        if offset < 0:
-            offset = 0
-
-        if limit < 0:
-            limit = LIMIT
-
-        fltr = {}
-        fltr['processing_date'] = get_date_range_filter(from_date, until_date)
-
-        fltr['document_type'] = u'press-release'
-
-        if collection:
-            fltr['collection'] = collection
-
-        if issn:
-            fltr['code_title'] = issn
-
-        total = self.db['articles'].find(fltr).count()
-        data = self.db['articles'].find(fltr, {
-            'code': 1,
-            'collection': 1,
-            'processing_date': 1,
-            'aid': 1,
-            'doi': 1}
-        ).sort('processing_date').skip(offset).limit(limit)
-
-        meta = {
-            'limit': limit,
-            'offset': offset,
-            'filter': fltr,
-            'total': total
-        }
-
-        result = {'meta': meta, 'objects': []}
-        for i in data:
-            rec = {
-                'code': i['code'],
-                'collection': i['collection'],
-                'processing_date': i['processing_date']
-            }
-            if 'aid' in i:
-                rec['aid'] = i['aid']
-
-            if 'doi' in i:
-                rec['doi'] = i['doi']
-
-            result['objects'].append(dates_to_string(rec))
-
-        result['meta']['filter'] = dates_to_string(result['meta']['filter'])
-
-        return result
-
-    def get_article(self, code, collection=None, replace_journal_metadata=False, body=False):
+    def get_article(self, code, collection=None, replace_journal_metadata=False,
+            body=False):
         """
             replace_journal_metadata: replace the content of the title attribute
             that cames with the article record. The content is replaced by the
@@ -910,109 +1153,16 @@ class DataBroker(object):
             of the journal data recorded when the article was inserted in the
             collection.
         """
+        return self.articlemeta.get(code=code, collection=collection,
+                replace_journal_metadata=replace_journal_metadata, body=body)
 
-        fltr = {'$or': [{'code': code}, {'doi': code}, {'aid': code}]}
-        if collection:
-            fltr['collection'] = collection
-
-        fields = None
-
-        if not body:
-            fields = {'body': 0}
-
-        if fields:
-            data = self.db['articles'].find_one(fltr, fields)
-        else:
-            data = self.db['articles'].find_one(fltr)
-
-        if not data:
-            return None
-
-        if replace_journal_metadata is True:
-            journal = self.get_journal(
-                collection=collection, issn=data['title']['v400'][0]['_'])
-
-            if journal and len(journal) != 0:
-                data['title'] = journal[0]
-
-        issue = self.get_issue(collection=collection, code=data['code'][1:18])
-
-        if issue:
-            data['issue'] = issue
-            if 'title' in data['issue']:
-                del(data['issue']['title'])
-
-        del(data['_id'])
-
-        return dates_to_string(data)
-
-    def get_articles_full(
-        self,
-        collection=None,
-        issn=None,
-        from_date='1500-01-01',
-        until_date=None,
-        limit=100,
-        offset=0,
-        extra_filter=None,
-        replace_journal_metadata=False,
-        body=False
-    ):
-
-        if offset < 0:
-            offset = 0
-
-        if limit < 0:
-            limit = 100
-
-        fltr = {}
-        fltr['processing_date'] = get_date_range_filter(from_date, until_date)
-
-        if collection:
-            fltr['collection'] = collection
-
-        if issn:
-            fltr['code_title'] = issn
-
-        if extra_filter:
-            fltr.update(json.loads(extra_filter))
-
-        content = {
-            '_id': 0
-        }
-
-        if body is False:
-            content['body'] = 0
-
-        total = self.db['articles'].find(fltr).count()
-        data = self.db['articles'].find(fltr, content
-        ).sort('processing_date').skip(offset).limit(limit)
-
-        meta = {
-            'limit': limit,
-            'offset': offset,
-            'filter': fltr,
-            'total': total
-        }
-
-        result = {'meta': meta, 'objects': []}
-        for article in data:
-            if replace_journal_metadata:
-                journal = self.get_journal(collection=collection, issn=article['title']['v400'][0]['_'])
-
-                if journal and len(journal) == 1:
-                    article['title'] = journal[0]
-
-            issue = self.get_issue(collection=collection, code=article['code_issue'])
-
-            if issue:
-                article['issue'] = issue
-
-            result['objects'].append(dates_to_string(article))
-
-        result['meta']['filter'] = dates_to_string(result['meta']['filter'])
-
-        return result
+    def get_articles_full(self, collection=None, issn=None,
+            from_date='1500-01-01', until_date=None, limit=100, offset=0,
+            extra_filter=None, replace_journal_metadata=False, body=False):
+        return self.articlemeta.get_articles_full(collection=collection,
+                issn=issn, from_date=from_date, until_date=until_date,
+                limit=limit, offset=offset, extra_filter=extra_filter,
+                replace_journal_metadata=replace_journal_metadata, body=body)
 
     def get_articles(self, code, collection=None, replace_journal_metadata=False):
 
@@ -1037,85 +1187,25 @@ class DataBroker(object):
             yield dates_to_string(article)
 
     def exists_article(self, code, collection=None):
-        fltr = {'code': code}
-
-        if collection:
-            fltr['collection'] = collection
-
-        if self.db['articles'].find(fltr).count() >= 1:
-            return True
-
-        return False
+        return self.articlemeta.exists(code=code, collection=collection)
 
     @LogHistoryChange(document_type="article", event_type="delete")
     def delete_article(self, code, collection=None):
-
-        fltr = {'code': code}
-
-        if collection:
-            fltr['collection'] = collection
-
-        deleted = self.db['articles'].delete_one(fltr)
-
-        fltr['code'] = code
-        fltr['deleted_count'] = deleted.deleted_count
-
-        return fltr
-
+        return self.articlemeta.delete(code=code, collection=collection)
 
     @LogHistoryChange(document_type="article", event_type="add")
     def add_article(self, metadata):
-
-        article = check_article_meta(metadata)
-
-        if not article:
-            return None
-
-        if self.exists_article(article['code'], article['collection']):
-            return self.update_article(article)
-
-        article['created_at'] = article['processing_date']
-
-        self.db['articles'].update_one(
-            {'code': article['code'], 'collection': article['collection']},
-            {'$set': article},
-            upsert=True
-        )
-
-        return dates_to_string(article)
+        return self.articlemeta.add(metadata)
 
     @LogHistoryChange(document_type="article", event_type="update")
     def update_article(self, metadata):
-
-        article = check_article_meta(metadata)
-
-        if not article:
-            return None
-
-        article['updated_at'] = datetime.now()
-
-        self.db['articles'].update_one(
-            {'code': article['code'], 'collection': article['collection']},
-            {'$set': article},
-            upsert=True
-        )
-
-        return dates_to_string(article)
+        return self.articlemeta.update(metadata)
 
     def set_doaj_id(self, code, collection, doaj_id):
-
-        fltr = {'code': code}
-
-        if collection:
-            fltr['collection'] = collection
-
-        self.db['articles'].update_one(fltr, {'$set': {'doaj_id': str(doaj_id)}})
+        return self.articlemeta.set_doaj_id(code=code, collection=collection,
+                doaj_id=doaj_id)
 
     def set_aid(self, code, collection, aid):
+        return self.articlemeta.set_aid(code=code, collection=collection,
+                aid=aid)
 
-        fltr = {'code': code}
-
-        if collection:
-            fltr['collection'] = collection
-
-        self.db['articles'].update_one(fltr, {'$set': {'aid': str(aid)}})


### PR DESCRIPTION
Nessa primeira parte:

1. Os métodos no estilo ``DataBroker.get_articles`` e ``DataBroker.get_issues`` deram origem a ``ArticleMeta.get`` e ``IssueMeta.get``;
2. Os nomes das bases de dados e coleções do MongoDB foram desacopladas dos métodos;
3. As dependências de dados de outras coleções do MongoDB foram explicitadas; Por exemplo: `IssueMeta` depende de `JournalMeta`.