### PR TITLE
[exportsci][tk122] Geração do XML da referência de página Web

### DIFF
--- a/articlemeta/export_sci.py
+++ b/articlemeta/export_sci.py
@@ -21,19 +21,21 @@ def create_children(root_node, tags, values):
     return root_node
 
 
-def date_iso_parts(date_iso):
+def splited_yyyy_mm_dd(date_iso):
     if date_iso is not None:
-        date_iso = date_iso[0]['_']
-        if date_iso[:8].isdigit():
-            y = date_iso[:4]
-            m = date_iso[4:6]
-            d = date_iso[6:8]
-            return (y, m, d)
+        parts = date_iso.split('-')
+        if len(parts) == 2:
+            parts.append(None)
+        if len(parts) == 1:
+            parts.append(None)
+            parts.append(None)
+        if len(parts) == 3:
+            return parts
 
 
-def create_date_elem(element_date_name, date_iso_parts, date_type=None):
-    if date_iso_parts is not None:
-        y, m, d = date_iso_parts
+def create_date_elem(element_date_name, splited_yyyy_mm_dd, date_type=None):
+    if splited_yyyy_mm_dd is not None:
+        y, m, d = splited_yyyy_mm_dd
         elem_date = ET.Element(element_date_name)
         if date_type is not None:
             elem_date.set('date-type', date_type)
@@ -206,14 +208,18 @@ class XMLCitation(object):
             elem.text = raw.link
             elem_citation.append(elem)
 
-            access_date_iso = raw.data.get('v110')
-            date_in_citation_elem = create_date_elem(
+            try:
+                access_date = raw.access_date
+            except AttributeError:
+                access_date = raw.date
+            if access_date is not None:
+                date_in_citation_elem = create_date_elem(
                     'date-in-citation',
-                    date_iso_parts(access_date_iso),
+                    splited_yyyy_mm_dd(access_date),
                     'access-date'
                 )
-            if date_in_citation_elem is not None:
-                elem_citation.append(date_in_citation_elem)
+                if date_in_citation_elem is not None:
+                    elem_citation.append(date_in_citation_elem)
 
             return data
 

--- a/tests/test_export_sci.py
+++ b/tests/test_export_sci.py
@@ -101,6 +101,46 @@ class XMLCitationTests(unittest.TestCase):
 
         self.assertEqual(u'http://www.scielo.br', expected)
 
+    def test_xml_citation_url_with_access_date_pipe(self):
+        link = {'_': 'www.vigna.com.br'}
+        access_date_ext = {'_': '10 de junho de 2012'}
+        access_date_iso = {'_': '20120610'}
+        citation = {}
+        citation['v37'] = [link]
+        citation['v109'] = [access_date_ext]
+        citation['v110'] = [access_date_iso]
+
+        fakexylosearticle = Article({'article': {},
+                                     'title': {},
+                                     'citations': [citation]}).citations[0]
+        pxml = ET.Element('ref')
+        pxml.append(ET.Element('element-citation'))
+
+        data = [fakexylosearticle, pxml]
+
+        raw, xml = self._xmlcitation.URIPipe().transform(data)
+
+        self.assertEqual(
+            [link['_']],
+            [node.text for node in xml.findall('./element-citation/ext-link')]
+        )
+        self.assertEqual(
+            '2012',
+            xml.find('./element-citation/date-in-citation/year').text
+        )
+        self.assertEqual(
+            '06',
+            xml.find('./element-citation/date-in-citation/month').text
+        )
+        self.assertEqual(
+            '10',
+            xml.find('./element-citation/date-in-citation/day').text
+        )
+        self.assertEqual(
+            'access-date',
+            xml.find('./element-citation/date-in-citation').get('date-type')
+        )
+
     def test_xml_citation_source_pipe(self):
 
         pxml = ET.Element('ref')
@@ -380,6 +420,55 @@ class XMLCitationTests(unittest.TestCase):
         expected = xml.find('./element-citation/person-group')
 
         self.assertEqual(None, expected)
+
+    def test_xml_citation_webpage_pipes(self):
+        link = {'_': 'www.vigna.com.br'}
+        access_date_ext = {'_': '10 de junho de 2012'}
+        access_date_iso = {'_': '20120610'}
+        citation = {}
+        citation['v37'] = [link]
+        citation['v109'] = [access_date_ext]
+        citation['v110'] = [access_date_iso]
+        citation['v701'] = [{'_': '1'}]
+        citation['v16'] = [{'s': 'Surname', 'n': 'Name'}]
+
+        fakexylosearticle = Article({'article': {},
+                                     'title': {},
+                                     'citations': [citation]}).citations[0]
+        pxml = ET.Element('ref')
+        data = [fakexylosearticle, pxml]
+
+        data = self._xmlcitation.RefIdPipe().transform(data)
+        data = self._xmlcitation.ElementCitationPipe().transform(data)
+        self.assertEqual(
+            1,
+            len(data[-1].findall('.//element-citation')))
+        data = self._xmlcitation.ArticleTitlePipe().transform(data)
+        data = self._xmlcitation.ThesisTitlePipe().transform(data)
+        data = self._xmlcitation.LinkTitlePipe().transform(data)
+        data = self._xmlcitation.SourcePipe().transform(data)
+        data = self._xmlcitation.DatePipe().transform(data)
+        data = self._xmlcitation.StartPagePipe().transform(data)
+        data = self._xmlcitation.EndPagePipe().transform(data)
+        data = self._xmlcitation.IssuePipe().transform(data)
+        data = self._xmlcitation.VolumePipe().transform(data)
+        data = self._xmlcitation.PersonGroupPipe().transform(data)
+        data = self._xmlcitation.URIPipe().transform(data)
+        xml = data[-1]
+        self.assertEqual(
+            xml.find('./element-citation').get('publication-type'), 'link')
+        self.assertEqual(
+            xml.find('.//person-group//surname').text, 'Surname')
+        self.assertEqual(
+            xml.find('.//person-group//given-names').text, 'Name')
+        self.assertEqual(
+            xml.find('.//date-in-citation/year').text, '2012')
+        self.assertEqual(
+            xml.find('.//date-in-citation/month').text, '06')
+        self.assertEqual(
+            xml.find('.//date-in-citation/day').text, '10')
+        self.assertEqual(
+            xml.find('.//ext-link').text, 'www.vigna.com.br')
 
 
 class ExportTests(unittest.TestCase):


### PR DESCRIPTION
Atualmente o XML gerado está incompleto:

```xml
<element-citation publication-type="undefined">
            <person-group>
              <name>
                <surname>Vigna</surname>
                <given-names>Elvira</given-names>
              </name>
              <name>
                <surname>Vigna</surname>
                <given-names>Elvira</given-names>
              </name>
            </person-group>
          </element-citation>
```

Deveria retornar algo como:
```xml
<ref id="B1">
    <element-citation publication-type="link">
       <person-group>
            <name><surname>Surname</surname><given-names>Name</given-names></name><name><surname>Surname</surname><given-names>Name</given-names></name></person-group>
       <ext-link ext-link-type="uri" href="www.vigna.com.br">www.vigna.com.br</ext-link>
       <date-in-citation date-type="access-date"><day>10</day><month>06</month><year>2012</year>
        </date-in-citation>
    </element-citation>
</ref>
```

Fixes #122