### PR TITLE
[exportsci][tk119] Retornar os autores em grupos: analítico e monográfico.

### DIFF
--- a/articlemeta/export_sci.py
+++ b/articlemeta/export_sci.py
@@ -287,7 +287,7 @@ class XMLCitation(object):
 
         @plumber.precondition(precond)
         def transform(self, data):
-            def get_name(author):
+            def create_elem_name(author):
                 name = ET.Element('name')
                 _surname = author.get('surname')
                 _given_names = author.get('given_names')
@@ -307,19 +307,18 @@ class XMLCitation(object):
                 return name
             raw, xml = data
 
-            persongroup = ET.Element('person-group')
-
-            if raw.authors:
-                for author in raw.authors:
-                    name = get_name(author)
-                    persongroup.append(name)
-
+            author_groups = []
+            if raw.analytic_authors:
+                author_groups.append(raw.analytic_authors)
             if raw.monographic_authors:
-                for author in raw.monographic_authors:
-                    name = get_name(author)
-                    persongroup.append(name)
+                author_groups.append(raw.monographic_authors)
 
-            xml.find('./element-citation').append(persongroup)
+            elem_citation = xml.find('./element-citation')
+            for author_group in author_groups:
+                persongroup = ET.Element('person-group')
+                for author in author_group:
+                    persongroup.append(create_elem_name(author))
+                elem_citation.append(persongroup)
 
             return data
 

--- a/tests/test_export_sci.py
+++ b/tests/test_export_sci.py
@@ -408,6 +408,48 @@ class XMLCitationTests(unittest.TestCase):
         self.assertEqual(len(gn), 0)
         self.assertEqual([u'Platão', u'Aristóteles'], surnames)
 
+    def test_xml_citation_person_groups_pipe(self):
+        analytic = [{'s': 'Fausto', 'r': 'ND', '_': '', 'n': u'N'},
+                    {'s': 'Laird', 'r': 'ND', '_': '', 'n': u'AD'},
+                    ]
+        monographic = [{'s': 'Mitchell', 'r': 'ND', '_': '', 'n': u'RH'},
+                       {'s': 'Ruff', 'r': 'ND', '_': '', 'n': u'S'},
+                       ]
+        citation = {}
+        citation['v10'] = analytic
+        citation['v16'] = monographic
+
+        fakexylosearticle = Article(
+                                {
+                                    'article': {},
+                                    'title': {},
+                                    'citations': [
+                                        citation
+                                    ]
+                                }
+                            ).citations[0]
+        pxml = ET.Element('ref')
+        pxml.append(ET.Element('element-citation'))
+
+        data = [fakexylosearticle, pxml]
+
+        raw, xml = self._xmlcitation.PersonGroupPipe().transform(data)
+
+        person_groups = xml.findall('./element-citation/person-group')
+        self.assertEqual(len(person_groups), 2)
+
+        expected = [
+            [('Fausto', 'N'), ('Laird', 'AD')],
+            [('Mitchell', 'RH'), ('Ruff', 'S')],
+        ]
+        for expected_names, person_group in zip(expected, person_groups):
+            names = []
+            for name in person_group.findall('name'):
+                item = (
+                    name.find('surname').text, name.find('given-names').text)
+                names.append(item)
+            self.assertEqual(names, expected_names)
+
     def test_xml_citation_conference_pipe(self):
         conf_name = {
             '_': u'Workshop Internacional sobre Clima'


### PR DESCRIPTION

Algumas referências têm mais de um grupo de autores (person-group): analítico e monográfico.
Considerar retornar os autores agrupados.

Fixes #119