### PR TITLE
[exportsci][tk118] Geração de 1 único elemento publisher

### DIFF
--- a/articlemeta/export_sci.py
+++ b/articlemeta/export_sci.py
@@ -486,6 +486,9 @@ class XMLJournalMetaCollectionPipe(plumber.Pipe):
 
 
 class XMLJournalMetaPublisherPipe(plumber.Pipe):
+    def transform(self, data):
+        return self.join_publisher_names(data, '; ')
+
     def join_publisher_names(self, data, separator='; '):
         raw, xml = data
         publisher_names = separator.join(raw.journal.publisher_name or [])
@@ -510,9 +513,6 @@ class XMLJournalMetaPublisherPipe(plumber.Pipe):
             publisher.append(publishername)
             xml.find('./article/front/journal-meta').append(publisher)
         return data
-
-    def transform(self, data):
-        return self.join_publisher_names(data, '; ')
 
 
 class XMLArticleMetaUniqueArticleIdPipe(plumber.Pipe):

--- a/articlemeta/export_sci.py
+++ b/articlemeta/export_sci.py
@@ -442,19 +442,33 @@ class XMLJournalMetaCollectionPipe(plumber.Pipe):
 
 
 class XMLJournalMetaPublisherPipe(plumber.Pipe):
-    def transform(self, data):
+    def join_publisher_names(self, data, separator='; '):
         raw, xml = data
+        publisher_names = separator.join(raw.journal.publisher_name or [])
 
-        for item in raw.journal.publisher_name or []:
-            publishername = ET.Element('publisher-name')
-            publishername.text = item
+        publishername = ET.Element('publisher-name')
+        publishername.text = publisher_names
 
-            publisher = ET.Element('publisher')
-            publisher.append(publishername)
+        publisher = ET.Element('publisher')
+        publisher.append(publishername)
 
-            xml.find('./article/front/journal-meta').append(publisher)
+        xml.find('./article/front/journal-meta').append(publisher)
 
         return data
+
+    def get_first_publisher_name(self, data):
+        raw, xml = data
+        publisher_names = raw.journal.publisher_name or []
+        if len(publisher_names) > 0:
+            publishername = ET.Element('publisher-name')
+            publishername.text = publisher_names[0]
+            publisher = ET.Element('publisher')
+            publisher.append(publishername)
+            xml.find('./article/front/journal-meta').append(publisher)
+        return data
+
+    def transform(self, data):
+        return self.join_publisher_names(data, '; ')
 
 
 class XMLArticleMetaUniqueArticleIdPipe(plumber.Pipe):

--- a/tests/test_export_sci.py
+++ b/tests/test_export_sci.py
@@ -641,6 +641,50 @@ class ExportTests(unittest.TestCase):
 
         self.assertEqual(u'Faculdade de Saúde Pública da Universidade de São Paulo', publishername)
 
+    def test_xmljournal_meta_publishers_join_publisher_names_pipe(self):
+        titles = {}
+        titles['v480'] = [
+            {'_': 'Publicador 1'},
+            {'_': 'Publicador 2'},
+        ]
+        fakexylosearticle = Article({'article': {}, 'title': titles})
+        pxml = ET.Element('articles')
+        pxml.append(ET.Element('article'))
+        article = pxml.find('article')
+        article.append(ET.Element('front'))
+        front = article.find('front')
+        front.append(ET.Element('journal-meta'))
+        data = [fakexylosearticle, pxml]
+        xmlarticle = export_sci.XMLJournalMetaPublisherPipe()
+        raw, xml = xmlarticle.join_publisher_names(data, ' | ')
+        publishers = xml.findall('./article/front/journal-meta/publisher')
+        self.assertEqual(1, len(publishers))
+        self.assertEqual(
+            'Publicador 1 | Publicador 2',
+            publishers[0].find('publisher-name').text)
+
+    def test_xmljournal_meta_publishers_get_first_publisher_name_pipe(self):
+        titles = {}
+        titles['v480'] = [
+            {'_': 'Publicador 1'},
+            {'_': 'Publicador 2'},
+        ]
+        fakexylosearticle = Article({'article': {}, 'title': titles})
+        pxml = ET.Element('articles')
+        pxml.append(ET.Element('article'))
+        article = pxml.find('article')
+        article.append(ET.Element('front'))
+        front = article.find('front')
+        front.append(ET.Element('journal-meta'))
+        data = [fakexylosearticle, pxml]
+        xmlarticle = export_sci.XMLJournalMetaPublisherPipe()
+        raw, xml = xmlarticle.get_first_publisher_name(data)
+        publishers = xml.findall('./article/front/journal-meta/publisher')
+        self.assertEqual(1, len(publishers))
+        self.assertEqual(
+            'Publicador 1',
+            publishers[0].find('publisher-name').text)
+
     def test_xml_article_meta_unique_article_id_pipe(self):
 
         pxml = ET.Element('articles')


### PR DESCRIPTION

Preparadas duas soluções alternativas:

 - ```join_publisher_name(data, separator)```
 - ```get_first_publisher_name(data)```

```transform()``` usa ```join_publisher_name(data, '; ')```


#118 