### PR TITLE
[exportsci][tk130] Corrige geração de person-group/collab 

### DIFF
--- a/articlemeta/export_sci.py
+++ b/articlemeta/export_sci.py
@@ -374,12 +374,15 @@ class XMLCitation(object):
             raw, xml = data
 
             elem_citation = xml.find('./element-citation')
-            for author_group in raw.authors_groups.values():
-                persongroup = ET.Element('person-group')
-                for author_type, authors in author_group.items():
-                    for author in authors:
-                        persongroup.append(self._create_author(author))
-                elem_citation.append(persongroup)
+            groups = raw.authors_groups
+            for group in ['analytic', 'monographic']:
+                author_group = groups.get(group)
+                if author_group is not None:
+                    persongroup = ET.Element('person-group')
+                    for author_type, authors in author_group.items():
+                        for author in authors:
+                            persongroup.append(self._create_author(author))
+                    elem_citation.append(persongroup)
 
             return data
 

--- a/articlemeta/export_sci.py
+++ b/articlemeta/export_sci.py
@@ -326,42 +326,96 @@ class XMLCitation(object):
         def precond(data):
             raw, xml = data
 
-            if not raw.authors and not raw.monographic_authors:
-                raise plumber.UnmetPrecondition()
+            try:
+                if not raw.authors_groups:
+                    raise plumber.UnmetPrecondition()
+            except AttributeError:
+                conditions = [
+                    raw.authors,
+                    raw.monographic_authors,
+                    raw.data.get('v11'),
+                    raw.data.get('v17')
+                ]
+                if any(conditions) is False:
+                    raise plumber.UnmetPrecondition()
+
+        def _create_author(self, author):
+            if not isinstance(author, dict):
+                element = ET.Element('collab')
+                element.text = author
+                return element
+            element = ET.Element('name')
+            _surname = author.get('surname')
+            _given_names = author.get('given_names')
+            if _surname == '' and _given_names:
+                _surname = _given_names
+                _given_names = ''
+            if _surname != '':
+                surname = ET.Element('surname')
+                surname.text = _surname
+                element.append(surname)
+            if _given_names != '':
+                givennames = ET.Element('given-names')
+                givennames.text = _given_names
+                element.append(givennames)
+            return element
 
         @plumber.precondition(precond)
         def transform(self, data):
-            def create_elem_name(author):
-                name = ET.Element('name')
-                _surname = author.get('surname')
-                _given_names = author.get('given_names')
-                if _surname == '' and _given_names:
-                    _surname = _given_names
-                    _given_names = ''
+            raw, xml = data
+            try:
+                if not raw.authors_groups:
+                    data = self._transform_authors_groups(data)
+            except AttributeError:
+                data = self._transform_authors(data)
+            return data
 
-                if _surname != '':
-                    surname = ET.Element('surname')
-                    surname.text = _surname
-                    name.append(surname)
-
-                if _given_names != '':
-                    givennames = ET.Element('given-names')
-                    givennames.text = _given_names
-                    name.append(givennames)
-                return name
+        def _transform_authors_groups(self, data):
             raw, xml = data
 
+            elem_citation = xml.find('./element-citation')
+            for author_group in raw.authors_groups.values():
+                persongroup = ET.Element('person-group')
+                for author_type, authors in author_group.items():
+                    for author in authors:
+                        persongroup.append(self._create_author(author))
+                elem_citation.append(persongroup)
+
+            return data
+
+        def _transform_authors(self, data):
+            raw, xml = data
+            analytics = raw.analytic_authors or []
+            analytics += raw.analytic_institution or []
+            if raw.analytic_institution is None and \
+                    raw.data.get('v11') is not None:
+                for institution in raw.data.get('v11', []):
+                    analytics.append(institution['_'])
+            aa = []
+            for author in analytics:
+                aa.append(self._create_author(author))
+
+            monographic = raw.monographic_authors or []
+            monographic += raw.monographic_institution or []
+            if raw.monographic_institution is None and \
+                    raw.data.get('v17') is not None:
+                for institution in raw.data.get('v17', []):
+                    monographic.append(institution['_'])
+            ma = []
+            for author in monographic:
+                ma.append(self._create_author(author))
+
             author_groups = []
-            if raw.analytic_authors:
-                author_groups.append(raw.analytic_authors)
-            if raw.monographic_authors:
-                author_groups.append(raw.monographic_authors)
+            if aa:
+                author_groups.append(aa)
+            if ma:
+                author_groups.append(ma)
 
             elem_citation = xml.find('./element-citation')
             for author_group in author_groups:
                 persongroup = ET.Element('person-group')
                 for author in author_group:
-                    persongroup.append(create_elem_name(author))
+                    persongroup.append(author)
                 elem_citation.append(persongroup)
 
             return data

--- a/tests/test_export_sci.py
+++ b/tests/test_export_sci.py
@@ -101,6 +101,78 @@ class XMLCitationTests(unittest.TestCase):
 
         self.assertEqual(u'http://www.scielo.br', expected)
 
+    def test_xml_citation_persongrouppipe_create_author_collab(self):
+        node = self._xmlcitation.PersonGroupPipe()._create_author(
+                'American Cancer Society')
+        self.assertEqual(
+            node.text,
+            'American Cancer Society'
+        )
+        self.assertEqual(
+            node.tag,
+            'collab'
+        )
+
+    def test_xml_citation_persongrouppipe_create_author_name(self):
+        author = {'surname': 'Silva', 'given_names': u'Paulo'}
+        node = self._xmlcitation.PersonGroupPipe()._create_author(
+                author)
+        self.assertEqual(
+            node.tag,
+            'name'
+        )
+        self.assertEqual(
+            node.find('given-names').text,
+            'Paulo'
+        )
+        self.assertEqual(
+            node.find('surname').text,
+            'Silva'
+        )
+
+    def test_xml_citation_corpauth_doctitle_url_pipe(self):
+
+        citation = {
+            'v11': [{'_': 'American Cancer Society'}],
+            'v12': [{'_': 'Colorectal Cancer Facts & Figures 2008-2010'}],
+            'v37': [{'_': 'http://www5.cancer.org/downloads/STT/F861708'}],
+
+        }
+        fakexylosearticle = Article({'article': {},
+                                     'title': {},
+                                     'citations': [
+                                        citation
+                                     ]}).citations[0]
+
+        pxml = ET.Element('ref')
+        data = [fakexylosearticle, pxml]
+
+        pipes = [
+                    self._xmlcitation.ElementCitationPipe,
+                    self._xmlcitation.URIPipe,
+                    self._xmlcitation.PersonGroupPipe,
+                    self._xmlcitation.LinkTitlePipe,
+                    self._xmlcitation.SourcePipe,
+            ]
+        for pipe in pipes:
+            raw, xml = pipe().transform(data)
+            data = raw, xml
+
+        self.assertEqual(
+            xml.find('./element-citation').get('publication-type'), 'link')
+
+        expected = xml.find('./element-citation/ext-link').text
+        self.assertEqual(
+            u'http://www5.cancer.org/downloads/STT/F861708', expected)
+
+        expected = xml.find('./element-citation/source').text
+        self.assertEqual(
+            u'Colorectal Cancer Facts & Figures 2008-2010', expected)
+
+        self.assertEqual(
+           xml.find('./element-citation/person-group/collab').text,
+           u'American Cancer Society')
+
     def test_xml_citation_url_with_access_date_pipe(self):
         link = {'_': 'www.vigna.com.br'}
         access_date_ext = {'_': '10 de junho de 2012'}
@@ -504,9 +576,17 @@ class XMLCitationTests(unittest.TestCase):
         monographic = [{'s': 'Mitchell', 'r': 'ND', '_': '', 'n': u'RH'},
                        {'s': 'Ruff', 'r': 'ND', '_': '', 'n': u'S'},
                        ]
+        analytic_inst = [{'_': 'UNESCO'},
+                         {'_': 'OMS'},
+                         ]
+        monographic_inst = [{'_': 'AABB'},
+                            {'_': 'W3C'},
+                            ]
         citation = {}
         citation['v10'] = analytic
         citation['v16'] = monographic
+        citation['v11'] = analytic_inst
+        citation['v17'] = monographic_inst
 
         fakexylosearticle = Article(
                                 {
@@ -528,16 +608,18 @@ class XMLCitationTests(unittest.TestCase):
         self.assertEqual(len(person_groups), 2)
 
         expected = [
-            [('Fausto', 'N'), ('Laird', 'AD')],
-            [('Mitchell', 'RH'), ('Ruff', 'S')],
+            [('Fausto', 'N'), ('Laird', 'AD'), 'UNESCO', 'OMS'],
+            [('Mitchell', 'RH'), ('Ruff', 'S'), 'AABB', 'W3C'],
         ]
-        for expected_names, person_group in zip(expected, person_groups):
-            names = []
+        for expected_items, person_group in zip(expected, person_groups):
+            items = []
             for name in person_group.findall('name'):
                 item = (
                     name.find('surname').text, name.find('given-names').text)
-                names.append(item)
-            self.assertEqual(names, expected_names)
+                items.append(item)
+            for collab in person_group.findall('collab'):
+                items.append(collab.text)
+            self.assertEqual(items, expected_items)
 
     def test_xml_citation_conference_pipe(self):
         conf_name = {


### PR DESCRIPTION
collab não era criado porque o xylose não retornava autores institucionais.


Fixes #130