### PR TITLE
[exportsci_tk130_v2] [exportsci][tk130] Corrige PersonGroupPipe.transform()

### DIFF
--- a/articlemeta/export_sci.py
+++ b/articlemeta/export_sci.py
@@ -363,7 +363,7 @@ class XMLCitation(object):
         def transform(self, data):
             raw, xml = data
             try:
-                if not raw.authors_groups:
+                if raw.authors_groups:
                     data = self._transform_authors_groups(data)
             except AttributeError:
                 data = self._transform_authors(data)

--- a/articlemeta/export_sci.py
+++ b/articlemeta/export_sci.py
@@ -363,26 +363,25 @@ class XMLCitation(object):
         def transform(self, data):
             raw, xml = data
             try:
-                if raw.authors_groups:
-                    data = self._transform_authors_groups(data)
+                data = self._transform_authors_groups(data)
             except AttributeError:
+                # caso não exista raw.authors_groups
                 data = self._transform_authors(data)
             return data
 
         def _transform_authors_groups(self, data):
             raw, xml = data
-
-            elem_citation = xml.find('./element-citation')
-            groups = raw.authors_groups
-            for group in ['analytic', 'monographic']:
-                author_group = groups.get(group)
-                if author_group is not None:
-                    persongroup = ET.Element('person-group')
-                    for author_type, authors in author_group.items():
-                        for author in authors:
-                            persongroup.append(self._create_author(author))
-                    elem_citation.append(persongroup)
-
+            if raw.authors_groups:
+                elem_citation = xml.find('./element-citation')
+                groups = raw.authors_groups
+                for group in ['analytic', 'monographic']:
+                    author_group = groups.get(group)
+                    if author_group is not None:
+                        persongroup = ET.Element('person-group')
+                        for author_type, authors in author_group.items():
+                            for author in authors:
+                                persongroup.append(self._create_author(author))
+                        elem_citation.append(persongroup)
             return data
 
         def _transform_authors(self, data):

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ thriftpy==0.3.9
 urllib3==1.22
 venusian==1.1.0
 WebOb==1.8.0rc1
-xylose==1.33.2
+xylose==1.34
 zope.deprecation==4.3.0
 zope.interface==4.4.3
 crossrefapi==1.3.0

--- a/tests/test_export_sci.py
+++ b/tests/test_export_sci.py
@@ -654,7 +654,7 @@ class XMLCitationTests(unittest.TestCase):
 
         data = [fakexylosearticle, pxml]
         raw, xml = data
-        authors = {}
+
         analytic = [{'surname': 'Fausto', 'given_names': u'N'},
                     {'surname': 'Laird', 'given_names': u'AD'},
                     ]
@@ -664,11 +664,14 @@ class XMLCitationTests(unittest.TestCase):
         analytic_inst = ['UNESCO', 'OMS']
         monographic_inst = ['AABB', 'W3C']
 
-        authors['analytic'] = {
-            'person': analytic, 'institution': analytic_inst}
-        authors['monographic'] = {
-            'person': monographic, 'institution': monographic_inst}
-        raw.authors_groups = authors
+        if not hasattr(raw, 'authors_groups'):
+            authors = {}
+            authors['analytic'] = {
+                'person': analytic, 'institution': analytic_inst}
+            authors['monographic'] = {
+                'person': monographic, 'institution': monographic_inst}
+            raw.authors_groups = authors
+
         data = raw, xml
         raw, xml = self._xmlcitation.PersonGroupPipe(
             )._transform_authors_groups(data)


### PR DESCRIPTION
Corrige defeitos apresentados após atualização de xylose==1.34

``PersonGroupPipe.transform()`` não está gerando os elementos ``<person-group>`` porque a verificação de existência do novo atributo do xylose ``authors_groups`` está incorreta.

Relacionado com #130

```
    class PersonGroupPipe(plumber.Pipe):
```
...
```
        @plumber.precondition(precond)
        def transform(self, data):
            raw, xml = data
            try:
                if not raw.authors_groups:
                    data = self._transform_authors_groups(data)
            except AttributeError:
                data = self._transform_authors(data)
            return data
```

Remover "not" de
```
                if not raw.authors_groups:
```
