### PR TITLE
Considerar .pdf como mais um dos padrões de arquivo fonte, além de xml e html

### DIFF
--- a/processing/load_languages.py
+++ b/processing/load_languages.py
@@ -80,15 +80,19 @@ def get_acron_issueid_fname_without_extension(file_path):
     - html: V:\\Scielo\\serial\\dpjo\\v15n3\\markup\\05.htm
     - pdf: d:/c.917173/scielo/serial.lilacs//mioc/v51/markup/v51/tomo51(f1)_17-74.pdf
     Retorna uma lista cujo itens sao
-    acron, issue, nome do arquivo sem extensao
+    acron, issue, nome do arquivo sem extensao, em minúsculas
+    - xml: (delta, v32n2, 1678-460x-delta-32-02-00543)
+    - html: (dpjo, v15n3, 05)
+    - pdf: (mioc, v51, tomo51(f1)_17-74)
     """
-    _file_path = file_path.lower().replace('\\', '/').replace('//', '/')
-
+    _file_path = os.path.normcase(os.path.normpath(file_path)).lower()
+    import pdb;pdb.set_trace()
     try:
         file_id = FILE_REGEX.search(_file_path).group()
         file_id = file_id.split('/')
         if not file_path.endswith('.xml'):
-            file_id = [item for item in file_id if item != 'markup']
+            file_id = [item for item in file_id if item not in ['markup', '']]
+            print(file_id)
             if file_id[-2] == file_id[-3]:
                 del file_id[-2]
             file_id = file_id[-3:]
@@ -96,7 +100,7 @@ def get_acron_issueid_fname_without_extension(file_path):
             logger.error(
                 u'Fail to parse file_path %s for %s', (file_path, file_id))
             return
-        file_id[-1] = file_id[-1][:file_id[-1].rfind('.')]
+        file_id[-1], ext = os.path.splitext(file_id[-1])
     except:
         logger.error(
             u'Fail to parse file_path %s for %s', (file_path, file_id))

--- a/processing/load_languages.py
+++ b/processing/load_languages.py
@@ -85,27 +85,25 @@ def get_acron_issueid_fname_without_extension(file_path):
     - html: (dpjo, v15n3, 05)
     - pdf: (mioc, v51, tomo51(f1)_17-74)
     """
-    _file_path = os.path.normcase(os.path.normpath(file_path)).lower()
-    import pdb;pdb.set_trace()
+    _file_path = os.path.normpath(file_path.replace('\\', '/')).lower()
     try:
         file_id = FILE_REGEX.search(_file_path).group()
-        file_id = file_id.split('/')
-        if not file_path.endswith('.xml'):
-            file_id = [item for item in file_id if item not in ['markup', '']]
-            print(file_id)
-            if file_id[-2] == file_id[-3]:
-                del file_id[-2]
-            file_id = file_id[-3:]
-        if len(file_id) != 3:
+        file_id, ext = os.path.splitext(file_id)
+        folders = file_id.split('/')
+        if not ext == '.xml':
+            folders = [item for item in folders if item not in ['markup', '']]
+            if folders[-2] == folders[-3]:
+                del folders[-2]
+            folders = folders[-3:]
+        if len(folders) != 3:
             logger.error(
                 u'Fail to parse file_path %s for %s', (file_path, file_id))
             return
-        file_id[-1], ext = os.path.splitext(file_id[-1])
     except:
         logger.error(
             u'Fail to parse file_path %s for %s', (file_path, file_id))
         return
-    return file_id
+    return folders
 
 
 def collections_acronym(articlemeta_db):

--- a/tests/test_load_languages.py
+++ b/tests/test_load_languages.py
@@ -36,6 +36,33 @@ class LoadLanguageTest(TestCase):
 
         self.mocked_db = MockedDB()
 
+    def test_get_acron_issueid_fname_without_extension(self):
+        get_file_id = load_languages.get_acron_issueid_fname_without_extension
+        self.assertEqual(
+            get_file_id('delta/v32n2/1678-460X-delta-32-02-00543.xml'),
+            ['delta', 'v32n2', '1678-460x-delta-32-02-00543']
+        )
+        self.assertEqual(
+            get_file_id('V:\\Scielo\\serial\\dpjo\\v15n3\\markup\\05.html'),
+            ['dpjo', 'v15n3', '05']
+        )
+        self.assertEqual(
+            get_file_id('C:\\SciELO\\Serial\\aa\\v34n1\\markup\\v34n1a06.html'),
+            ['aa', 'v34n1', 'v34n1a06']
+        )
+        self.assertEqual(
+            get_file_id(
+                'd:/c.917173/scielo/serial.lilacs//'
+                'mioc/v51/markup/v51/tomo51(f1)_17-74.pdf'),
+            ['mioc', 'v51', 'tomo51(f1)_17-74']
+        )
+        self.assertEqual(
+            get_file_id(
+                '/scielo/serial.lilacs//mioc/v82s3/'
+                'markup/v82s3/vol82(fsup3)_II.pdf'),
+            ['mioc', 'v82s3', 'vol82(fsup3)_ii']
+        )
+
     def test_run(self):
         mocked_articlemeta_db = mongomock.MongoClient().db
         mocked_articlemeta_db['collections'].insert_many([


### PR DESCRIPTION
Padrões possíveis:
 - xml: delta/v32n2/1678-460X-delta-32-02-00543.xml
 - html: V:\\Scielo\\serial\\dpjo\\v15n3\\markup\\05.htm
 - pdf: d:/c.917173/scielo/serial.lilacs//mioc/v51/markup/v51/tomo51(f1)_17-74.pdf

Fixes #145