### PR TITLE
O fmt=opac deve retornar "fulltexts"

### DIFF
--- a/articlemeta/export.py
+++ b/articlemeta/export.py
@@ -221,7 +221,7 @@ class Export(object):
         article = self._article.copy()
         keys_to_remove = ['citations', '_shard_id', 'validated_scielo',
                 'doaj_id', 'normalized', 'sent_doaj', 'sent_wos',
-                'validated_wos', 'applicable', 'fulltexts']
+                'validated_wos', 'applicable']
 
         for k in keys_to_remove:
             try:


### PR DESCRIPTION
#### What's this PR do?
Faz com que o "fulltexts" volte a ser retornado

#### Where should the reviewer start?
articlemeta/export.py

#### How should this be manually tested?
```
from articlemeta.client import ThriftClient
cl = ThriftClient()
article = cl.document(code='S0074-02761929000100003', collection='scl', fmt='opac')
article.data['fulltexts']

```

Retorno esperado:

```json
{"pdf": 
{"fr": "http://www.scielo.br/pdf/mioc/v22n1/fr_tomo22(f1)_135-139.pdf",
"pt": "http://www.scielo.br/pdf/mioc/v22n1/tomo22(f1)_135-139.pdf"},
"html": 
{"pt": "http://www.scielo.br/scielo.php?script=sci_arttext&pid=S0074-02761929000100003&tlng=pt"}}
```

#### Any background context you want to provide?
"fulltexts" foi erroneamente removido ao solucionar #116.

#### What are the relevant tickets?
Fixes #149

#### Screenshots (if appropriate)
n/a

#### Questions:
n/a

tk149