### PR TITLE
O fmt=opac deve retornar "fulttexts"

### DIFF
--- a/articlemeta/export.py
+++ b/articlemeta/export.py
@@ -195,7 +195,7 @@ class Export(object):
         article = self._article.copy()
         keys_to_remove = ['citations', '_shard_id', 'validated_scielo',
                 'doaj_id', 'normalized', 'sent_doaj', 'sent_wos',
-                'validated_wos', 'applicable', 'fulltexts']
+                'validated_wos', 'applicable']
 
         for k in keys_to_remove:
             try:

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ test_requires = ['mocker', 'nose>=1.0', 'coverage', 'mongomock']
 
 setup(
     name="articlemeta",
-    version='1.44.0',
+    version='1.45.0',
     description="A SciELO API to load SciELO Articles metadata",
     author="SciELO",
     author_email="scielo-dev@googlegroups.com",


### PR DESCRIPTION
#### What's this PR do?
Faz com que o "fulltexts" volte a ser retornado

#### Where should the reviewer start?
articlemeta/export.py

#### How should this be manually tested?
```
from articlemeta.client import ThriftClient
cl = ThriftClient()
article = cl.document(code='S0074-02761929000100003', collection='scl', fmt='opac')
article.data['fulltexts']

```

Retorno esperado:

```json
{"pdf": 
{"fr": "http://www.scielo.br/pdf/mioc/v22n1/fr_tomo22(f1)_135-139.pdf",
"pt": "http://www.scielo.br/pdf/mioc/v22n1/tomo22(f1)_135-139.pdf"},
"html": 
{"pt": "http://www.scielo.br/scielo.php?script=sci_arttext&pid=S0074-02761929000100003&tlng=pt"}}
```

#### Any background context you want to provide?
"fulltexts" foi erroneamente removido ao solucionar #116.

#### What are the relevant tickets?
Fixes #149

#### Screenshots (if appropriate)
n/a

#### Questions:
n/a

tk149

master_tk149