### PR TITLE
Correção no retorno de identificadores da coleção

### DIFF
--- a/articlemeta/data/collections.json
+++ b/articlemeta/data/collections.json
@@ -112,13 +112,18 @@
     "is_active": true
   },
   {
+    "acron": "bks",
+    "code": "books",
     "domain": "books.scielo.org",
+    "acron2": "bk",
     "name": {
       "en": "SciELO Books",
       "pt": "SciELO Livros",
       "es": "SciELO Libros"
     },
     "has_analytics": false,
+    "original_name": "SciELO Books",
+    "status": "independent",
     "type": "books",
     "is_active": true
   },

--- a/articlemeta/thrift/server.py
+++ b/articlemeta/thrift/server.py
@@ -81,9 +81,14 @@ class Dispatcher(object):
             raise articlemeta_thrift.ServerError(
                 'Server error: DataBroker.identifiers_collection')
 
-        return [articlemeta_thrift.collection(i['code'], i['acron'],
-            i['acron2'], i['status'], i['domain'], i['original_name'],
-            i['has_analytics'], i['is_active'], i['type']) for i in data]
+        return [
+            articlemeta_thrift.collection(i['code'], i['acron'], i['acron2'],
+                                          i['status'], i['domain'],
+                                          i['original_name'],
+                                          i['has_analytics'], i['is_active'],
+                                          i['type'])
+            for i in data
+            if i.get('type') == 'journals']
 
     def get_collection(self, code):
 

--- a/articlemeta/thrift/server.py
+++ b/articlemeta/thrift/server.py
@@ -85,10 +85,9 @@ class Dispatcher(object):
             articlemeta_thrift.collection(i['code'], i['acron'], i['acron2'],
                                           i['status'], i['domain'],
                                           i['original_name'],
-                                          i['has_analytics'], i['is_active'],
-                                          i['type'])
-            for i in data
-            if i.get('type') == 'journals']
+                                          i['has_analytics'],
+                                          i.get('is_active'), i.get('type'))
+            for i in data]
 
     def get_collection(self, code):
 
@@ -101,7 +100,7 @@ class Dispatcher(object):
         return articlemeta_thrift.collection(data['code'], data['acron'],
                                              data['acron2'], data['status'],
                                              data['domain'], data['original_name'],
-                                             data['has_analytics'], 
+                                             data['has_analytics'],
                                              data['is_active'], data['type'])
 
     def article_history_changes(self, collection, event, code, from_date,

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ test_requires = ['mocker', 'nose>=1.0', 'coverage', 'mongomock']
 
 setup(
     name="articlemeta",
-    version='1.45.0',
+    version='1.45.1',
     description="A SciELO API to load SciELO Articles metadata",
     author="SciELO",
     author_email="scielo-dev@googlegroups.com",


### PR DESCRIPTION
#### O que esse PR faz?
Corrige pontualmente no Thrift Server o retorno de `get_collection_identifiers()`, que espera alguns dados vindos somente nos identifiers do tipo "journals"

#### Onde a revisão poderia começar?
Em `articlemeta/thrift/server.py`, no método `get_collection_identifiers()`

#### Como este poderia ser testado manualmente?
Utilizar o script `articlemeta/thrift/client_sample.py`, alterando as configurações do AM, e executar:
`client.get_collection_identifiers()`

#### Algum cenário de contexto que queira dar?
O seguinte dado nos identifiers de coleções está retornando do AM e causando o erro no Thrift Server:
```
{
  'domain': 'books.scielo.org',
  'has_analytics': False,
  'is_active': True,
  'name': {'en': 'SciELO Books', 'es': 'SciELO Libros', 'pt': 'SciELO Livros'},
  'type': 'books'
 }
```
Por não conter dados necessários para a resposta, um erro ocorre.

#### Quais são tickets relevantes?
Related to #155 

#### Screenshots (se aplicável)
N/A

#### Perguntas:
N/A
