### PR TITLE
Trata retorno no get_collection do Thrift e adiciona logs debug

### DIFF
--- a/articlemeta/thrift/server.py
+++ b/articlemeta/thrift/server.py
@@ -87,20 +87,32 @@ class Dispatcher(object):
 
     def get_collection(self, code):
 
+        logger.debug('AM Thrift - get_collection: %s' % code)
         try:
             data = self._databroker.get_collection(code)
         except:
             raise articlemeta_thrift.ServerError(
                 'Server error: DataBroker.get_collection')
 
+        if not data:
+            raise articlemeta_thrift.ValueError(
+                'Value error: no collection %s' % code)
+
         return articlemeta_thrift.collection(data['code'], data['acron'],
-                                             data['acron2'], data['status'],
+                                             data.get('acron2', ''), data.get('status', ''),
                                              data['domain'], data['original_name'],
                                              data['has_analytics'],
-                                             data['is_active'], data['type'])
+                                             data.get('is_active', False), data.get('type', ''))
 
     def article_history_changes(self, collection, event, code, from_date,
                                 until_date, limit, offset):
+
+        logger.debug(
+            'AM Thrift - article_history_changes: %s %s %s' % (
+                collection,
+                event,
+                code)
+        )
 
         from_date = from_date or '1500-01-01'
         limit = limit or 1000
@@ -129,6 +141,13 @@ class Dispatcher(object):
 
     def issue_history_changes(self, collection, event, code, from_date,
                               until_date, limit, offset):
+
+        logger.debug(
+            'AM Thrift - issue_history_changes: %s %s %s' % (
+                collection,
+                event,
+                code)
+        )
 
         from_date = from_date or '1500-01-01'
         limit = limit or 1000
@@ -164,6 +183,10 @@ class Dispatcher(object):
         body=False
     ):
 
+        logger.debug(
+            'AM Thrift - get_articles: %s %s' % (collection, issn)
+        )
+
         from_date = from_date or '1500-01-01'
         limit = limit or 100
         offset = offset or 0
@@ -188,6 +211,10 @@ class Dispatcher(object):
 
     def get_article_identifiers(self, collection, issn, from_date, until_date,
                                 limit, offset, extra_filter=None):
+
+        logger.debug(
+            'AM Thrift - get_article_identifiers: %s %s' % (collection, issn)
+        )
 
         from_date = from_date or '1500-01-01'
         limit = limit or 1000
@@ -221,6 +248,10 @@ class Dispatcher(object):
         limit, offset, extra_filter=None
     ):
 
+        logger.debug(
+            'AM Thrift - get_issues: %s %s' % (collection, issn)
+        )
+
         from_date = from_date or '1500-01-01'
         limit = limit or 100
         offset = offset or 0
@@ -243,6 +274,10 @@ class Dispatcher(object):
 
     def get_issue_identifiers(self, collection, issn, from_date, until_date,
                                 limit, offset, extra_filter=None):
+
+        logger.debug(
+            'AM Thrift - get_issue_identifiers: %s %s' % (collection, issn)
+        )
 
         from_date = from_date or '1500-01-01'
         limit = limit or 1000
@@ -271,6 +306,10 @@ class Dispatcher(object):
 
     def delete_journal(self, code, collection, admintoken):
 
+        logger.debug(
+            'AM Thrift - delete_journal: %s %s' % (code, collection)
+        )
+
         if admintoken != self._admintoken:
             raise articlemeta_thrift.Unauthorized(
                 'Unautorized Access: Invalid admin token')
@@ -288,6 +327,10 @@ class Dispatcher(object):
                 'Server error: DataBroker.delete_journal')
 
     def delete_issue(self, code, collection, admintoken):
+
+        logger.debug(
+            'AM Thrift - delete_issue: %s %s' % (code, collection)
+        )
 
         if admintoken != self._admintoken:
             raise articlemeta_thrift.Unauthorized(
@@ -307,6 +350,10 @@ class Dispatcher(object):
 
     def delete_article(self, code, collection, admintoken):
 
+        logger.debug(
+            'AM Thrift - delete_article: %s %s' % (code, collection)
+        )
+
         if admintoken != self._admintoken:
             raise articlemeta_thrift.Unauthorized(
                 'Unautorized Access: Invalid admin token')
@@ -324,6 +371,8 @@ class Dispatcher(object):
                 'Server error: DataBroker.delete_journal')
 
     def add_journal(self, metadata, admintoken):
+        logger.debug('AM Thrift - add_journal: %s' % metadata)
+
         if admintoken != self._admintoken:
             raise articlemeta_thrift.Unauthorized(
                 'Unautorized Access: Invalid admin token')
@@ -349,6 +398,8 @@ class Dispatcher(object):
             'Server error: DataBroker.add_journal, Nondata inserted')
 
     def add_article(self, metadata, admintoken):
+        logger.debug('AM Thrift - add_article: %s' % metadata)
+
         if admintoken != self._admintoken:
             raise articlemeta_thrift.Unauthorized(
                 'Unautorized Access: Invalid admin token')
@@ -374,6 +425,8 @@ class Dispatcher(object):
             'Server error: DataBroker.add_article, Nondata inserted')
 
     def add_issue(self, metadata, admintoken):
+        logger.debug('AM Thrift - add_issue: %s' % metadata)
+
         if admintoken != self._admintoken:
             raise articlemeta_thrift.Unauthorized(
                 'Unautorized Access: Invalid admin token')
@@ -399,6 +452,13 @@ class Dispatcher(object):
             'Server error: DataBroker.add_issue, Nondata inserted')
 
     def get_article(self, code, collection, replace_journal_metadata, fmt, body=False):
+
+        logger.debug(
+            'AM Thrift - get_article: %s %s %s' % (
+                code,
+                collection,
+                replace_journal_metadata)
+        )
 
         try:
             data = self._databroker.get_article(
@@ -434,6 +494,13 @@ class Dispatcher(object):
 
     def get_issue(self, code, collection, replace_journal_metadata):
 
+        logger.debug(
+            'AM Thrift - get_issue: %s %s %s' % (
+                code,
+                collection,
+                replace_journal_metadata)
+        )
+
         try:
             data = self._databroker.get_issue(
                 code,
@@ -448,6 +515,10 @@ class Dispatcher(object):
 
     def journal_history_changes(self, collection, event=None, code=None, from_date=None,
                                 until_date=None, limit=None, offset=None):
+
+        logger.debug(
+            'AM Thrift - journal_history_changes: %s' % collection
+        )
 
         from_date = from_date or '1500-01-01'
         limit = limit or 1000
@@ -476,6 +547,10 @@ class Dispatcher(object):
 
     def get_journal_identifiers(self, collection, issn=None, limit=None, offset=None, extra_filter=None):
 
+        logger.debug(
+            'AM Thrift - get_journal_identifiers: %s' % collection
+        )
+
         limit = limit or 0
         offset = offset or 0
 
@@ -500,6 +575,10 @@ class Dispatcher(object):
 
     def get_journal(self, code, collection):
 
+        logger.debug(
+            'AM Thrift - get_journal: %s %s' % (code, collection)
+        )
+
         try:
             data = self._databroker.get_journal(collection=collection,
                                                 issn=code)
@@ -513,6 +592,10 @@ class Dispatcher(object):
         return json.dumps(data)
 
     def set_doaj_id(self, code, collection, doaj_id, admintoken):
+        logger.debug(
+            'AM Thrift - get_journal: %s %s %s' % (code, collection, doaj_id)
+        )
+
         if admintoken != self._admintoken:
             raise articlemeta_thrift.Unauthorized(
                 'Unautorized Access: Invalid admin token')
@@ -541,6 +624,10 @@ class Dispatcher(object):
         return False
 
     def exists_article(self, code, collection):
+        logger.debug(
+            'AM Thrift - exists_article: %s %s' % (code, collection)
+        )
+
         try:
             return self._databroker.exists_article(code, collection)
         except:
@@ -550,6 +637,10 @@ class Dispatcher(object):
         return False
 
     def exists_issue(self, code, collection):
+        logger.debug(
+            'AM Thrift - exists_issue: %s %s' % (code, collection)
+        )
+
         try:
             return self._databroker.exists_issue(code, collection)
         except:
@@ -559,6 +650,10 @@ class Dispatcher(object):
         return False
 
     def exists_journal(self, code, collection):
+        logger.debug(
+            'AM Thrift - exists_journal: %s %s' % (code, collection)
+        )
+
         try:
             return self._databroker.exists_journal(code, collection)
         except:
@@ -568,6 +663,13 @@ class Dispatcher(object):
         return False
 
     def get_issue_code_from_label(self, label, journal_code, collection):
+        logger.debug(
+            'AM Thrift - get_issue_code_from_label: %s %s %s' % (
+                label,
+                journal_code,
+                collection)
+        )
+
         try:
             return self._databroker.get_issue_code_from_label(label,
                     journal_code, collection)

--- a/articlemeta/thrift/server.py
+++ b/articlemeta/thrift/server.py
@@ -87,7 +87,7 @@ class Dispatcher(object):
 
     def get_collection(self, code):
 
-        logger.debug('AM Thrift - get_collection: %s' % code)
+        logger.debug('AM Thrift - get_collection(code=%s)' % code)
         try:
             data = self._databroker.get_collection(code)
         except:
@@ -108,10 +108,10 @@ class Dispatcher(object):
                                 until_date, limit, offset):
 
         logger.debug(
-            'AM Thrift - article_history_changes: %s %s %s' % (
-                collection,
-                event,
-                code)
+            'AM Thrift - article_history_changes('
+            'collection=%s,event=%s,code=%s,from_date=%s,'
+            'until_date=%s,limit=%s,offset=%s)'
+            % (collection, event, code, from_date, until_date, limit, offset)
         )
 
         from_date = from_date or '1500-01-01'
@@ -143,10 +143,10 @@ class Dispatcher(object):
                               until_date, limit, offset):
 
         logger.debug(
-            'AM Thrift - issue_history_changes: %s %s %s' % (
-                collection,
-                event,
-                code)
+            'AM Thrift - issue_history_changes('
+            'collection=%s,event=%s,code=%s,from_date=%s,'
+            'until_date=%s,limit=%s,offset=%s)'
+            % (collection, event, code, from_date, until_date, limit, offset)
         )
 
         from_date = from_date or '1500-01-01'
@@ -184,7 +184,11 @@ class Dispatcher(object):
     ):
 
         logger.debug(
-            'AM Thrift - get_articles: %s %s' % (collection, issn)
+            'AM Thrift - get_articles('
+            'collection=%s,issn=%s,from_date=%s,until_date=%s,limit=%s,'
+            'offset=%s,extra_filter=%s,replace_journal_metadata=%s,body=%s)'
+            % (collection, issn, from_date, until_date, limit, offset,
+                extra_filter, replace_journal_metadata, body)
         )
 
         from_date = from_date or '1500-01-01'
@@ -213,7 +217,10 @@ class Dispatcher(object):
                                 limit, offset, extra_filter=None):
 
         logger.debug(
-            'AM Thrift - get_article_identifiers: %s %s' % (collection, issn)
+            'AM Thrift - get_article_identifiers('
+            'collection=%s,issn=%s,from_date=%s,until_date=%s,limit=%s,'
+            'offset=%s,extra_filter=%s)'
+            % (collection, issn, from_date, until_date, limit, offset, extra_filter)
         )
 
         from_date = from_date or '1500-01-01'
@@ -249,7 +256,10 @@ class Dispatcher(object):
     ):
 
         logger.debug(
-            'AM Thrift - get_issues: %s %s' % (collection, issn)
+            'AM Thrift - get_issues('
+            'collection=%s,issn=%s,from_date=%s,until_date=%s,limit=%s,'
+            'offset=%s,extra_filter=%s)'
+            % (collection, issn, from_date, until_date, limit, offset, extra_filter)
         )
 
         from_date = from_date or '1500-01-01'
@@ -276,7 +286,10 @@ class Dispatcher(object):
                                 limit, offset, extra_filter=None):
 
         logger.debug(
-            'AM Thrift - get_issue_identifiers: %s %s' % (collection, issn)
+            'AM Thrift - get_issue_identifiers('
+            'collection=%s,issn=%s,from_date=%s,until_date=%s,limit=%s,'
+            'offset=%s,extra_filter=%s)'
+            % (collection, issn, from_date, until_date, limit, offset, extra_filter)
         )
 
         from_date = from_date or '1500-01-01'
@@ -307,7 +320,8 @@ class Dispatcher(object):
     def delete_journal(self, code, collection, admintoken):
 
         logger.debug(
-            'AM Thrift - delete_journal: %s %s' % (code, collection)
+            'AM Thrift - delete_journal(code=%s,collection=%s)'
+            % (code, collection)
         )
 
         if admintoken != self._admintoken:
@@ -329,7 +343,8 @@ class Dispatcher(object):
     def delete_issue(self, code, collection, admintoken):
 
         logger.debug(
-            'AM Thrift - delete_issue: %s %s' % (code, collection)
+            'AM Thrift - delete_issue(code=%s,collection%s)'
+            % (code, collection)
         )
 
         if admintoken != self._admintoken:
@@ -351,7 +366,8 @@ class Dispatcher(object):
     def delete_article(self, code, collection, admintoken):
 
         logger.debug(
-            'AM Thrift - delete_article: %s %s' % (code, collection)
+            'AM Thrift - delete_article(code=%s,collection%s)'
+            % (code, collection)
         )
 
         if admintoken != self._admintoken:
@@ -371,7 +387,9 @@ class Dispatcher(object):
                 'Server error: DataBroker.delete_journal')
 
     def add_journal(self, metadata, admintoken):
-        logger.debug('AM Thrift - add_journal: %s' % metadata)
+        logger.debug(
+            'AM Thrift - add_journal(metadata=%s)' % metadata
+        )
 
         if admintoken != self._admintoken:
             raise articlemeta_thrift.Unauthorized(
@@ -398,7 +416,9 @@ class Dispatcher(object):
             'Server error: DataBroker.add_journal, Nondata inserted')
 
     def add_article(self, metadata, admintoken):
-        logger.debug('AM Thrift - add_article: %s' % metadata)
+        logger.debug(
+            'AM Thrift - add_article(metadata=%s)' % metadata
+        )
 
         if admintoken != self._admintoken:
             raise articlemeta_thrift.Unauthorized(
@@ -425,7 +445,9 @@ class Dispatcher(object):
             'Server error: DataBroker.add_article, Nondata inserted')
 
     def add_issue(self, metadata, admintoken):
-        logger.debug('AM Thrift - add_issue: %s' % metadata)
+        logger.debug(
+            'AM Thrift - add_issue(metadata=%s)' % metadata
+        )
 
         if admintoken != self._admintoken:
             raise articlemeta_thrift.Unauthorized(
@@ -454,10 +476,9 @@ class Dispatcher(object):
     def get_article(self, code, collection, replace_journal_metadata, fmt, body=False):
 
         logger.debug(
-            'AM Thrift - get_article: %s %s %s' % (
-                code,
-                collection,
-                replace_journal_metadata)
+            'AM Thrift - get_article('
+            'code=%s,collection=%s,replace_journal_metadata=%s,fmt=%s,body=%s)'
+            % (code, collection, replace_journal_metadata, fmt, body)
         )
 
         try:
@@ -495,10 +516,8 @@ class Dispatcher(object):
     def get_issue(self, code, collection, replace_journal_metadata):
 
         logger.debug(
-            'AM Thrift - get_issue: %s %s %s' % (
-                code,
-                collection,
-                replace_journal_metadata)
+            'AM Thrift - get_issue(code=%s,collection=%s,replace_journal_metadata=%s)'
+            % (code, collection, replace_journal_metadata)
         )
 
         try:
@@ -517,7 +536,10 @@ class Dispatcher(object):
                                 until_date=None, limit=None, offset=None):
 
         logger.debug(
-            'AM Thrift - journal_history_changes: %s' % collection
+            'AM Thrift - journal_history_changes('
+            'collection=%s,event=%s,code=%s,from_date=%s,'
+            'until_date=%s,limit=%s,offset=%s)'
+            % collection
         )
 
         from_date = from_date or '1500-01-01'
@@ -548,7 +570,9 @@ class Dispatcher(object):
     def get_journal_identifiers(self, collection, issn=None, limit=None, offset=None, extra_filter=None):
 
         logger.debug(
-            'AM Thrift - get_journal_identifiers: %s' % collection
+            'AM Thrift - get_journal_identifiers('
+            'collection=%s,issn=%s,limit=%s,offset=%s,extra_filter=%s)'
+            % (collection, issn, limit, offset, extra_filter)
         )
 
         limit = limit or 0
@@ -576,7 +600,7 @@ class Dispatcher(object):
     def get_journal(self, code, collection):
 
         logger.debug(
-            'AM Thrift - get_journal: %s %s' % (code, collection)
+            'AM Thrift - get_journal(code=%s,collection=%s)' % (code, collection)
         )
 
         try:
@@ -593,7 +617,8 @@ class Dispatcher(object):
 
     def set_doaj_id(self, code, collection, doaj_id, admintoken):
         logger.debug(
-            'AM Thrift - get_journal: %s %s %s' % (code, collection, doaj_id)
+            'AM Thrift - set_doaj_id(code=%s,collection=%s,doaj_id=%s)'
+            % (code, collection, doaj_id)
         )
 
         if admintoken != self._admintoken:
@@ -610,6 +635,11 @@ class Dispatcher(object):
         return False
 
     def set_aid(self, code, collection, aid, admintoken):
+        logger.debug(
+            'AM Thrift - set_aid(code=%s,collection=%s,aid=%s)'
+            % (code, collection, aid)
+        )
+
         if admintoken != self._admintoken:
             raise articlemeta_thrift.Unauthorized(
                 'Unautorized Access: Invalid admin token')
@@ -625,7 +655,7 @@ class Dispatcher(object):
 
     def exists_article(self, code, collection):
         logger.debug(
-            'AM Thrift - exists_article: %s %s' % (code, collection)
+            'AM Thrift - exists_article(code=%s,collection=%s)' % (code, collection)
         )
 
         try:
@@ -638,7 +668,7 @@ class Dispatcher(object):
 
     def exists_issue(self, code, collection):
         logger.debug(
-            'AM Thrift - exists_issue: %s %s' % (code, collection)
+            'AM Thrift - exists_issue(code=%s,collection=%s)' % (code, collection)
         )
 
         try:
@@ -651,7 +681,7 @@ class Dispatcher(object):
 
     def exists_journal(self, code, collection):
         logger.debug(
-            'AM Thrift - exists_journal: %s %s' % (code, collection)
+            'AM Thrift - exists_journal(code=%s,collection=%s)' % (code, collection)
         )
 
         try:
@@ -664,10 +694,8 @@ class Dispatcher(object):
 
     def get_issue_code_from_label(self, label, journal_code, collection):
         logger.debug(
-            'AM Thrift - get_issue_code_from_label: %s %s %s' % (
-                label,
-                journal_code,
-                collection)
+            'AM Thrift - get_issue_code_from_label(label=%s,journal_code=%s,collection=%s)'
+            % (label, journal_code, collection)
         )
 
         try:

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ requires = [
     'pyramid>=1.5.4',
     'thriftpy>=0.3.1',
     'thriftpywrap',
-    'xylose',
+    'xylose<=1.34.1',
     'crossrefapi>=1.3',
     ]
 


### PR DESCRIPTION
- Em `thrift.server.Dispacher.get_collection()`, lança exceção caso o retorno de `DataBroker.get_collection()` seja None. Também trata os parâmetros opcionais desse retorno.
- Adiciona logs de debug na entrada de todos os métodos
