### PR TITLE
Atualização da versão do xylose para v1.35.1 para resolver problema d…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ thriftpy==0.3.9
 urllib3==1.22
 venusian==1.1.0
 WebOb==1.8.0rc1
-xylose==1.34
+xylose==1.35.1
 zope.deprecation==4.3.0
 zope.interface==4.4.3
 crossrefapi==1.3.0

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ requires = [
     'pyramid>=1.5.4',
     'thriftpy>=0.3.1',
     'thriftpywrap',
-    'xylose<=1.34.1',
+    'xylose',
     'crossrefapi>=1.3',
     ]
 


### PR DESCRIPTION
…e quebra com versão anterior

#### What's this PR do?
Atualização da versão do xylose para v1.35.1

#### Where should the reviewer start?
N/A

#### How should this be manually tested?
N/A

#### Any background context you want to provide?
O erro aparecia ao rodar os testes do articles_meta no Travis.
O erro era o uso de xylose==1.35.0

```
======================================================================
ERROR: test_xmlarticle_meta_article_categories_without_data_pipe (tests.test_export_rsps.ExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/roberta.takenaka/github.com/scieloorg/articles_meta/tests/test_export_rsps.py", line 687, in test_xmlarticle_meta_article_categories_without_data_pipe
    raw, xml = xmlarticle.transform(data)
  File "/Users/roberta.takenaka/.virtualenvs/articles_meta-env/lib/python3.6/site-packages/plumber.py", line 104, in decorated
    precond(data)
  File "/Users/roberta.takenaka/github.com/scieloorg/articles_meta/articlemeta/export_rsps.py", line 678, in precond
    if not raw.original_section():
  File "/Users/roberta.takenaka/github.com/scieloorg/articles_meta/.eggs/xylose-1.35.0-py3.6.egg/xylose/scielodocument.py", line 1608, in original_section
    if self.section:
  File "/Users/roberta.takenaka/github.com/scieloorg/articles_meta/.eggs/xylose-1.35.0-py3.6.egg/xylose/scielodocument.py", line 1629, in section
    return self.issue.sections.get(self.section_code or '', None) if self.issue.sections else None
  File "/Users/roberta.takenaka/github.com/scieloorg/articles_meta/.eggs/xylose-1.35.0-py3.6.egg/xylose/scielodocument.py", line 1541, in issue
    msg = 'Issue metadata not found for the document %s' % self.publisher_id
  File "/Users/roberta.takenaka/github.com/scieloorg/articles_meta/.eggs/xylose-1.35.0-py3.6.egg/xylose/scielodocument.py", line 2083, in publisher_id
    return self.data['article']['v880'][0]['_']
KeyError: 'v880'

```

#### What are the relevant tickets?
N/A

#### Screenshots (if appropriate)
N/A
