### PR TITLE
[DOIMultilingue] Incluir no XML do CrossRef um DOI para cada versão (idioma) de documento

### DIFF
--- a/articlemeta/export.py
+++ b/articlemeta/export.py
@@ -19,6 +19,39 @@ class CustomArticle(Article):
         else:
             return None
 
+    @property
+    def text_langs(self):
+        _langs = self.xml_languages() or \
+                 (self.translated_htmls() or {}).keys() or \
+                 self.languages() or []
+        langs = [self.original_language()]
+        langs += [lang for lang in _langs if lang != langs[0]]
+        return langs
+
+    @property
+    def derivate_translations_doi(self):
+        """Cria DOI para as traduções derivando de DOI principal + . + lang"""
+        if self.doi:
+            return {
+                lang: '{}.{}'.format(self.doi, lang)
+                for lang in self.text_langs[1:]
+            }
+        return {}
+
+    @property
+    def document_doi_and_lang(self):
+        if self.data.get('doi_for_translation') != 'derivate':
+            return self.doi_and_lang
+        doi_and_lang = dict(self.doi_and_lang)
+        items = []
+        for lang in self.text_langs:
+            doi = doi_and_lang.get(lang) or \
+                  self.derivate_translations_doi.get(lang)
+            if doi:
+                items.append((lang, doi))
+        return items
+
+
 class JournalExport:
     def __init__(self, journal):
         self._journal = journal

--- a/articlemeta/export_crossref.py
+++ b/articlemeta/export_crossref.py
@@ -3,7 +3,7 @@ from lxml import etree as ET
 import re
 import os
 import uuid
-
+from copy import deepcopy
 from datetime import datetime
 
 from xylose.scielodocument import UnavailableMetadataException
@@ -318,11 +318,13 @@ class XMLJournalArticlePipe(plumber.Pipe):
     def transform(self, data):
         raw, xml = data
 
-        el = ET.Element('journal_article')
-        el.set('publication_type', 'full_text')
-        el.set('reference_distribution_opts', 'any')
-        xml.find('./body/journal').append(el)
-
+        journal = xml.find('./body/journal')
+        for item in raw.document_doi_and_lang:
+            el = ET.Element('journal_article')
+            el.set('language', item[0])
+            el.set('publication_type', 'full_text')
+            el.set('reference_distribution_opts', 'any')
+            journal.append(el)
         return data
 
 
@@ -330,11 +332,9 @@ class XMLArticleTitlesPipe(plumber.Pipe):
 
     def transform(self, data):
         raw, xml = data
-
         el = ET.Element('titles')
-
-        xml.find('./body/journal/journal_article').append(el)
-
+        for ja in xml.findall('.//journal_article'):
+            ja.append(deepcopy(el))
         return data
 
 
@@ -342,12 +342,24 @@ class XMLArticleTitlePipe(plumber.Pipe):
 
     def transform(self, data):
         raw, xml = data
+        doi_and_lang = raw.document_doi_and_lang
+        nodes = xml.findall('.//journal_article')
 
-        el = ET.Element('title')
-        el.text = raw.original_title() or '[NO TITLE AVAILABLE]'
-
-        xml.find('./body/journal/journal_article/titles').append(el)
-
+        for ja, _doi_and_lang in zip(nodes, doi_and_lang):
+            node = ja.find('./titles')
+            el = ET.Element('title')
+            lang, doi = _doi_and_lang
+            if lang == raw.original_language():
+                # el.set('language', lang)
+                el.text = raw.original_title() or '[NO TITLE AVAILABLE]'
+                node.append(el)
+            else:
+                el.text = raw.translated_titles().get(lang) or '[NO TITLE AVAILABLE]'
+                el_original = ET.Element('original_language_title')
+                el_original.set('language', raw.original_language())
+                el_original.text = raw.original_title()
+                node.append(el)
+                node.append(el_original)
         return data
 
 
@@ -416,7 +428,9 @@ class XMLArticleContributorsPipe(plumber.Pipe):
                 orcid.text = 'http://orcid.org/%s' % authors['orcid']
                 author.append(orcid)
 
-        xml.find('./body/journal/journal_article').append(el)
+        for journal_article in xml.findall('./body/journal//journal_article'):
+            new_el = deepcopy(el)
+            journal_article.append(new_el)
 
         return data
 
@@ -434,21 +448,23 @@ class XMLArticleAbstractPipe(plumber.Pipe):
     def transform(self, data):
         raw, xml = data
 
-        if raw.original_abstract():
-            paragraph = ET.Element('{http://www.ncbi.nlm.nih.gov/JATS1}p')
-            paragraph.text = raw.original_abstract()
-            el = ET.Element('{http://www.ncbi.nlm.nih.gov/JATS1}abstract')
-            el.set('{http://www.w3.org/XML/1998/namespace}lang', raw.original_language())
-            el.append(paragraph)
-            xml.find('./body/journal/journal_article').append(el)
+        for journal_article in xml.findall('./body/journal//journal_article'):
 
-        for language, body in raw.translated_abstracts().items():
-            paragraph = ET.Element('{http://www.ncbi.nlm.nih.gov/JATS1}p')
-            paragraph.text = body
-            el = ET.Element('{http://www.ncbi.nlm.nih.gov/JATS1}abstract')
-            el.set('{http://www.w3.org/XML/1998/namespace}lang', language)
-            el.append(paragraph)
-            xml.find('./body/journal/journal_article').append(el)
+            if raw.original_abstract():
+                paragraph = ET.Element('{http://www.ncbi.nlm.nih.gov/JATS1}p')
+                paragraph.text = raw.original_abstract()
+                el = ET.Element('{http://www.ncbi.nlm.nih.gov/JATS1}abstract')
+                el.set('{http://www.w3.org/XML/1998/namespace}lang', raw.original_language())
+                el.append(paragraph)
+                journal_article.append(el)
+
+            for language, body in raw.translated_abstracts().items():
+                paragraph = ET.Element('{http://www.ncbi.nlm.nih.gov/JATS1}p')
+                paragraph.text = body
+                el = ET.Element('{http://www.ncbi.nlm.nih.gov/JATS1}abstract')
+                el.set('{http://www.w3.org/XML/1998/namespace}lang', language)
+                el.append(paragraph)
+                journal_article.append(el)
 
         return data
 
@@ -458,7 +474,6 @@ class XMLArticlePubDatePipe(plumber.Pipe):
     def transform(self, data):
         raw, xml = data
 
-        journal_article = xml.find('./body/journal/journal_article')
         date = raw.publication_date
 
         el = ET.Element('publication_date')
@@ -480,7 +495,8 @@ class XMLArticlePubDatePipe(plumber.Pipe):
             year.text = date[0:4]
             el.append(year)
 
-        journal_article.append(el)
+        for journal_article in xml.findall('./body/journal//journal_article'):
+            journal_article.append(deepcopy(el))
 
         return data
 
@@ -515,7 +531,8 @@ class XMLPagesPipe(plumber.Pipe):
             otherpage.text = raw.end_page
             el.append(otherpage)
 
-        xml.find('./body/journal/journal_article').append(el)
+        for journal_article in xml.findall('./body/journal//journal_article'):
+            journal_article.append(deepcopy(el))
 
         return data
 
@@ -532,7 +549,8 @@ class XMLPIDPipe(plumber.Pipe):
         el = ET.Element('publisher_item')
         el.append(identifier)
 
-        xml.find('./body/journal/journal_article').append(el)
+        for journal_article in xml.findall('./body/journal//journal_article'):
+            journal_article.append(deepcopy(el))
 
         return data
 
@@ -544,7 +562,8 @@ class XMLDOIDataPipe(plumber.Pipe):
 
         el = ET.Element('doi_data')
 
-        xml.find('./body/journal/journal_article').append(el)
+        for journal_article in xml.findall('./body/journal//journal_article'):
+            journal_article.append(deepcopy(el))
 
         return data
 
@@ -554,23 +573,38 @@ class XMLDOIPipe(plumber.Pipe):
     def transform(self, data):
         raw, xml = data
 
-        doi = ET.Element('doi')
-        doi.text = raw.doi
-
-        xml.find('./body/journal/journal_article/doi_data').append(doi)
+        nodes = xml.findall('./body/journal//journal_article/doi_data')
+        for _doi_data, _doi_and_lang in zip(nodes, raw.document_doi_and_lang):
+            doi = ET.Element('doi')
+            doi.text = _doi_and_lang[1]
+            _doi_data.append(doi)
 
         return data
 
 
 class XMLResourcePipe(plumber.Pipe):
 
+    ARTICLE_URL = 'http://{}/scielo.php?script=sci_arttext&pid={}&tlng={}'
+
+    def precond(data):
+        raw, xml = data
+        try:
+            if not raw.scielo_domain or not raw.publisher_id:
+                raise plumber.UnmetPrecondition()
+        except:
+            raise plumber.UnmetPrecondition()
+
+    @plumber.precondition(precond)
     def transform(self, data):
         raw, xml = data
 
-        resource = ET.Element('resource')
-        resource.text = raw.html_url(language=raw.original_language())
-
-        xml.find('./body/journal/journal_article/doi_data').append(resource)
+        nodes = xml.findall('./body/journal//journal_article/doi_data')
+        for _doi_data, _doi_and_lang in zip(nodes, raw.document_doi_and_lang):
+            resource = ET.Element('resource')
+            resource.text = self.ARTICLE_URL.format(
+                    raw.scielo_domain, raw.publisher_id, _doi_and_lang[0]
+                )
+            _doi_data.append(resource)
 
         return data
 
@@ -584,27 +618,9 @@ class XMLCollectionPipe(plumber.Pipe):
         if not raw.fulltexts().get('pdf', None):
             raise plumber.UnmetPrecondition()
 
-    @plumber.precondition(precond)
-    def transform(self, data):
-        raw, xml = data
-
-        languages = [i for i in raw.fulltexts().get('pdf', {}).keys()]
-
-        if len(languages) == 0:
-            return data
-
-        res = None
-        if raw.original_language() in languages:
-            res = raw.fulltexts()['pdf'][raw.original_language()]
-        else:
-            res = raw.fulltexts()['pdf'][languages[0]]
-
-
-        if not res:
-            return data
-
+    def create_collection_element(self, resource_value):
         resource = ET.Element('resource')
-        resource.text = res
+        resource.text = resource_value
 
         item = ET.Element('item')
         item.set('crawler', 'iParadigms')
@@ -613,8 +629,18 @@ class XMLCollectionPipe(plumber.Pipe):
         collection = ET.Element('collection')
         collection.set('property', 'crawler-based')
         collection.append(item)
+        return collection
 
-        xml.find('./body/journal/journal_article/doi_data').append(collection)
+    @plumber.precondition(precond)
+    def transform(self, data):
+        raw, xml = data
+        pdf_items = raw.fulltexts().get('pdf')
+        for doi_data, doi_and_lang in zip(
+                xml.findall('.//journal_article/doi_data'),
+                raw.document_doi_and_lang):
+            collection = self.create_collection_element(
+                pdf_items.get(doi_and_lang[0]))
+            doi_data.append(collection)
 
         return data
 
@@ -632,14 +658,14 @@ class XMLArticleCitationsPipe(plumber.Pipe):
     def transform(self, data):
         raw, xml = data
 
-        article = xml.find('./body/journal/journal_article')
-        article.append(ET.Element('citation_list'))
-
-        citations = article.find('citation_list')
+        citations = ET.Element('citation_list')
 
         cit = XMLCitation()
         for citation in raw.citations:
             citations.append(cit.deploy(citation)[1])
+
+        for ja in xml.findall('.//journal_article'):
+            ja.append(deepcopy(citations))
 
         return data
 
@@ -940,5 +966,80 @@ class XMLClosePipe(plumber.Pipe):
 
         data = ET.tostring(
             xml, encoding="utf-8", method="xml", xml_declaration=True)
+
+        return data
+
+
+class XMLProgramPipe(plumber.Pipe):
+
+    def transform(self, data):
+        raw, xml = data
+        data = self._transform_original(data)
+        data = self._transform_translations(data)
+        return data
+
+    def _transform_original(self, data):
+        raw, xml = data
+
+        journal_article_node = xml.find('.//journal_article')
+
+        doi_and_lang = raw.document_doi_and_lang[1:]
+
+        # program
+        program_node = ET.Element('program')
+        program_node.set('xmlns',  'http://www.crossref.org/relations.xsd')
+
+        translated_titles = raw.translated_titles()
+        for lang, doi in doi_and_lang:
+
+            # program/related_item
+            related_item_node = ET.Element('related_item')
+
+            # program/related_item/description
+            description_node = ET.Element('description')
+            description_node.text = translated_titles.get(lang)
+            related_item_node.append(description_node)
+
+            # program/related_item/intra_work_relation
+            intra_work_relation_node = ET.Element('intra_work_relation')
+            intra_work_relation_node.set(
+                'relationship-type', 'isTranslationOf')
+            intra_work_relation_node.set('identifier-type', 'doi')
+            intra_work_relation_node.text = doi
+            related_item_node.append(intra_work_relation_node)
+
+            program_node.append(related_item_node)
+
+        journal_article_node.append(program_node)
+
+        return data
+
+    def _transform_translations(self, data):
+        raw, xml = data
+
+        for journal_article_node in xml.findall('.//journal_article')[1:]:
+
+            # program
+            program_node = ET.Element('program')
+            program_node.set('xmlns',  'http://www.crossref.org/relations.xsd')
+
+            # program/related_item
+            related_item_node = ET.Element('related_item')
+
+            # program/related_item/description
+            description_node = ET.Element('description')
+            description_node.text = raw.original_title()
+            related_item_node.append(description_node)
+
+            # program/related_item/intra_work_relation
+            intra_work_relation_node = ET.Element('intra_work_relation')
+            intra_work_relation_node.set(
+                'relationship-type', 'isTranslationOf')
+            intra_work_relation_node.set('identifier-type', 'doi')
+            intra_work_relation_node.text = raw.doi
+            related_item_node.append(intra_work_relation_node)
+
+            program_node.append(related_item_node)
+            journal_article_node.append(program_node)
 
         return data

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,8 @@ thriftpy==0.3.9
 urllib3==1.22
 venusian==1.1.0
 WebOb==1.8.0rc1
-xylose==1.35.1
+#xylose==1.35.1
+-e git+https://github.com/scieloorg/xylose.git@1.35.3#egg=xylose
 zope.deprecation==4.3.0
 zope.interface==4.4.3
 crossrefapi==1.3.0

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ requires = [
     'pyramid>=1.5.4',
     'thriftpy>=0.3.1',
     'thriftpywrap',
-    'xylose',
+    'xylose>=1.35.3',
     'crossrefapi>=1.3',
     ]
 
@@ -43,7 +43,8 @@ setup(
         "Topic :: Utilities",
     ],
     dependency_links=[
-        "git+https://github.com/scieloorg/thriftpy-wrap@0.1.1#egg=thriftpywrap"
+        "git+https://github.com/scieloorg/thriftpy-wrap@0.1.1#egg=thriftpywrap",
+        "git+https://github.com/scieloorg/xylose.git@1.35.3#egg=xylose",
     ],
     include_package_data=True,
     zip_safe=False,

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,0 +1,141 @@
+# coding: utf-8
+import unittest
+from articlemeta.export import CustomArticle as Article
+
+
+class ExportTests(unittest.TestCase):
+    def setUp(self):
+        self.article_json = {
+            "article": {
+                "v40": [{"_": "pt"}],
+                "v601": [{"_": "es"}, {"_": "en"}],
+                "v237": [{"_": "10.1590/S0034-89102010000400007"}],
+                },
+            "body": {
+                "es": "Body ES",
+                "en": "Body EN"
+            },
+        }
+
+    def test_derivate_translations_doi(self):
+        article = Article(self.article_json)
+        self.assertEqual(
+            article.derivate_translations_doi,
+            {
+                "es": "10.1590/S0034-89102010000400007.es",
+                "en": "10.1590/S0034-89102010000400007.en",
+            },
+        )
+
+    def test_document_doi_and_lang_no_doi(self):
+        article_json = {
+            "article": {
+                "v40": [{"_": "pt"}],
+                "v601": [{"_": "es"}, {"_": "en"}],
+                },
+            }
+        article_json.update({"doi_for_translation": "derivate"})
+        article = Article(article_json)
+        self.assertEqual(article.document_doi_and_lang, [])
+
+    def test_document_doi_and_lang_only_one_doi(self):
+        article_json = {
+            "article": {
+                "v40": [{"_": "pt"}],
+                "v601": [{"_": "es"}, {"_": "en"}],
+                "v237": [{"_": "10.1590/S0034-89102010000400007"}],
+            }
+        }
+        article = Article(article_json)
+        self.assertEqual(
+            article.document_doi_and_lang, [("pt", "10.1590/S0034-89102010000400007")]
+        )
+
+    def test_document_doi_and_lang_derivated_doi(self):
+        article_json = {
+            "article": {
+                "v40": [{"_": "pt"}],
+                "v601": [{"_": "es"}, {"_": "en"}],
+                "v237": [{"_": "10.1590/S0034-89102010000400007"}],
+            }
+        }
+        article_json.update({"doi_for_translation": "derivate"})
+        article = Article(article_json)
+        self.assertEqual(
+            article.document_doi_and_lang,
+            [
+                ("pt", "10.1590/S0034-89102010000400007"),
+                ("es", "10.1590/S0034-89102010000400007.es"),
+                ("en", "10.1590/S0034-89102010000400007.en"),
+            ],
+        )
+
+    def test_document_doi_and_lang_provided_doi(self):
+        article_json = {
+            "article": {
+                "v40": [{"_": "pt"}],
+                "v601": [{"_": "es"}, {"_": "en"}],
+                "v237": [{"_": "10.1590/S0034-89102010000400007"}],
+                "v337": [
+                    {"d": "10.1590/S0034-89102010000400007", "l": "pt"},
+                    {"d": "10.1590/S0034-89102010000400007.spanish", "l": "es"},
+                    {"d": "10.1590/S0034-89102010000400007.english", "l": "en"},
+                ],
+            }
+        }
+        article = Article(article_json)
+        self.assertEqual(
+            article.document_doi_and_lang,
+            [
+                ("pt", "10.1590/S0034-89102010000400007"),
+                ("es", "10.1590/S0034-89102010000400007.spanish"),
+                ("en", "10.1590/S0034-89102010000400007.english"),
+            ],
+        )
+
+    def test_document_doi_and_lang_provided_doi_with_configuration_derivated(self):
+        article_json = {
+            "article": {
+                "v40": [{"_": "pt"}],
+                "v601": [{"_": "es"}, {"_": "en"}],
+                "v237": [{"_": "10.1590/S0034-89102010000400007"}],
+                "v337": [
+                    {"d": "10.1590/S0034-89102010000400007", "l": "pt"},
+                    {"d": "10.1590/S0034-89102010000400007.spanish", "l": "es"},
+                    {"d": "10.1590/S0034-89102010000400007.english", "l": "en"},
+                ],
+            }
+        }
+        article_json.update({"doi_for_translation": "derivate"})
+        article = Article(article_json)
+        self.assertEqual(
+            article.document_doi_and_lang,
+            [
+                ("pt", "10.1590/S0034-89102010000400007"),
+                ("es", "10.1590/S0034-89102010000400007.spanish"),
+                ("en", "10.1590/S0034-89102010000400007.english"),
+            ],
+        )
+
+    def test_document_doi_and_lang_provided_and_derivated_doi(self):
+        article_json = {
+            "article": {
+                "v40": [{"_": "pt"}],
+                "v601": [{"_": "es"}, {"_": "en"}],
+                "v237": [{"_": "10.1590/S0034-89102010000400007"}],
+                "v337": [
+                    {"d": "10.1590/S0034-89102010000400007", "l": "pt"},
+                    {"d": "10.1590/S0034-89102010000400007.english", "l": "en"},
+                ],
+            }
+        }
+        article_json.update({"doi_for_translation": "derivate"})
+        article = Article(article_json)
+        self.assertEqual(
+            article.document_doi_and_lang,
+            [
+                ("pt", "10.1590/S0034-89102010000400007"),
+                ("es", "10.1590/S0034-89102010000400007.es"),
+                ("en", "10.1590/S0034-89102010000400007.english"),
+            ],
+        )

--- a/tests/test_export_crossref.py
+++ b/tests/test_export_crossref.py
@@ -11,6 +11,38 @@ from articlemeta import export
 from articlemeta.export import CustomArticle as Article
 
 
+def create_xmlcrossref_with_journal_element(journal_child_name=None):
+    xmlcrossref = ET.Element('doi_batch')
+    journal = ET.Element('journal')
+    if journal_child_name:
+        journal_child = ET.Element(journal_child_name)
+        journal.append(journal_child)
+    body = ET.Element('body')
+    body.append(journal)
+
+    xmlcrossref.append(body)
+    return xmlcrossref
+
+
+def create_xmlcrossref_with_n_journal_article_element(
+        languages, journal_article_child_name=None):
+    xmlcrossref = ET.Element('doi_batch')
+    body = ET.Element('body')
+    journal = ET.Element('journal')
+    for lang in languages:
+        journal_article = ET.Element('journal_article')
+        journal_article.set('language', lang)
+        journal_article.set('publication_type', 'full_text')
+        if journal_article_child_name:
+            journal_article_child = ET.Element(journal_article_child_name)
+            journal_article.append(journal_article_child)
+        journal.append(journal_article)
+    body.append(journal)
+
+    xmlcrossref.append(body)
+    return xmlcrossref
+
+
 class ExportTests(unittest.TestCase):
 
     def setUp(self):
@@ -276,7 +308,7 @@ class ExportTests(unittest.TestCase):
         xmlcrossref = export_crossref.XMLJournalArticlePipe()
         raw, xml = xmlcrossref.transform(data)
 
-        self.assertEqual(b'<doi_batch><body><journal><journal_article publication_type="full_text" reference_distribution_opts="any"/></journal></body></doi_batch>', ET.tostring(xml))
+        self.assertEqual(b'<doi_batch><body><journal><journal_article language="pt" publication_type="full_text" reference_distribution_opts="any"/></journal></body></doi_batch>', ET.tostring(xml))
 
     def test_article_titles_element(self):
 
@@ -438,3 +470,502 @@ class ExportTests(unittest.TestCase):
 
         self.assertTrue(schema.validate(xmlio))
         self.assertEqual(None, schema.assertValid(xmlio))
+
+
+class ExportCrossRef_MultiLingue_Document_Tests(unittest.TestCase):
+
+    def setUp(self):
+        article_json = {
+            "fulltexts": {
+                "pdf": {
+                    "es": "http://www.scielo.br/pdf/rsp/v44n4/es_07.pdf",
+                    "en": "http://www.scielo.br/pdf/rsp/v44n4/en_07.pdf",
+                    "pt": "http://www.scielo.br/pdf/rsp/v44n4/07.pdf"
+                },
+                "html": {
+                    "es": "http://www.scielo.br/scielo.php?script=sci_arttext&pid=S0034-89102010000400007&tlng=es",
+                    "en": "http://www.scielo.br/scielo.php?script=sci_arttext&pid=S0034-89102010000400007&tlng=en",
+                    "pt": "http://www.scielo.br/scielo.php?script=sci_arttext&pid=S0034-89102010000400007&tlng=pt"
+                }
+            },
+            "collection": "scl",
+            "doi": "10.1590/S0034-89102010000400007",
+            "body": {
+                "pt": "Body PT",
+                "es": "Body ES",
+                "en": "Body EN"
+            },
+            "article": {
+                "v880": [
+                    {
+                        "_": "S0034-89102010000400007"
+                    }
+                ],
+                "v237": [
+                    {
+                        "_": "10.1590/S0034-89102010000400007"
+                    }
+                ],
+                "v223": [
+                    {
+                        "_": "20100801"
+                    }
+                ],
+                "v65": [
+                    {
+                        "_": "2010"
+                    }
+                ],
+                "v601": [
+                    {
+                        "_": "en"
+                    },
+                    {
+                        "_": "es"
+                    },
+                ],
+                "v40": [
+                    {
+                        "_": "pt"
+                    }
+                ],
+                "v10": [
+                    {
+                        "s": "Bamgboye",
+                        "r": "ND",
+                        "_": "",
+                        "n": "EL"
+                    }
+                ],
+                "v14": [
+                    {
+                        "f": "14",
+                        "l": "20",
+                    }
+                ],
+                "v12": [
+                    {
+                        "l": "pt",
+                        "_": "Perfil epidemiológico dos pacientes em terapia"
+                        " renal substitutiva no Brasil, 2000-2004"
+                    },
+                    {
+                        "l": "en",
+                        "_": "Epidemiological profile of patients on"
+                        " renal replacement therapy in Brazil, 2000-2004"
+                    },
+                    {
+                        "l": "es",
+                        "_": "Perfil epidemiológico de los pacientes en terapia"
+                        " renal substitutiva en Brasil, 2000-2004"
+                    }
+                ],
+                "v337": [
+                    {
+                        "l": "en",
+                        "d": "10.1590/ID.en"
+                    },
+                    {
+                        "l": "es",
+                        "d": "10.1590/ID.es"
+                    }
+
+                ],
+                "v83": [
+                    {
+                        "a": "OBJETIVO: Descrever o perfil epidemiol\u00f3gico e cl\u00ednico de pacientes em terapia renal substitutiva, identificando fatores associados ao risco de morte. M\u00c9TODOS: Estudo observacional, prospectivo n\u00e3o concorrente, a partir de dados de 90.356 pacientes da Base Nacional em Terapias Renais Substitutivas, no Brasil. Foi realizado relacionamento determin\u00edstico-probabil\u00edstico do Sistema de Autoriza\u00e7\u00e3o de Procedimentos de Alta Complexidade/Custo e do Sistema de Informa\u00e7\u00e3o de Mortalidade. Foram inclu\u00eddos todos os pacientes incidentes que iniciaram di\u00e1lise entre 1/1/2000 e 31/12/2004, acompanhados at\u00e9 a morte ou final de 2004. Idade, sexo, regi\u00e3o de resid\u00eancia, doen\u00e7a renal prim\u00e1ria, causa do \u00f3bito foram analisados. Ajustou-se um modelo de riscos proporcionais para identificar fatores associados ao risco de morte. RESULTADOS: Ocorreu um aumento m\u00e9dio de 5,5% na preval\u00eancia de pacientes em terapia enquanto a incid\u00eancia manteve-se est\u00e1vel no per\u00edodo. Hemodi\u00e1lise foi a modalidade inicial predominante (89%). A maioria dos pacientes era do sexo masculino, com idade m\u00e9dia de 53 anos, residente na regi\u00e3o Sudeste, e apresentava causa indeterminada como principal causa b\u00e1sica da doen\u00e7a renal cr\u00f4nica, seguida da hipertens\u00e3o, diabetes e glomerulonefrites. Desses pacientes, 7% realizou transplante renal e 42% evoluiu para o \u00f3bito. Os pacientes em di\u00e1lise peritoneal eram mais idosos e apresentavam maior preval\u00eancia de diabetes. Entre os n\u00e3o transplantados, 45% foi a \u00f3bito e, entre os transplantados, 7%. No modelo final de riscos proporcionais de Cox, o risco de mortalidade foi associado com o aumento da idade, sexo feminino, ter diabetes, residir nas regi\u00f5es Norte e Nordeste, di\u00e1lise peritoneal como modalidade de entrada e n\u00e3o ter realizado transplante renal. CONCLUS\u00d5ES: Houve aumento da preval\u00eancia de pacientes em terapia renal no Brasil. Pacientes com idade avan\u00e7ada, diabetes, do sexo feminino, residentes nas regi\u00f5es Norte e Nordeste e sem transplante renal apresentam maior risco de morte.", 
+                        "l": "pt",
+                        "_": ""
+                    },
+                    {
+                        "a": "OBJECTIVE: To describe the clinical and epidemiological profile of patients under renal replacement therapies, identifying risk factors for death. METHODS: This is a non-concurrent cohort study of data for 90,356 patients in the National Renal Replacement Therapies Database. A deterministic-probabilistic linkage was performed using the Authorization System for High Complexity/Cost Procedures and the Mortality Information System databases. All patients who started dialysis between 1/1/2000 and 12/31/2004 were included and followed until death or the end of 2004. Age, sex, region of residence, primary renal disease and causes of death were analyzed. A proportional hazards model was used to identify factors associated with risk of death. RESULTS: The prevalence of patients under renal replacement therapies increased an average of 5.5%, while incidence remained stable during the period. Hemodialysis was the predominant initial modality (89%). The patients were majority male with mean age 53 years, residents of the Southeast region and presented unknown causes as the main cause of chronic renal disease, followed by hypertension, diabetes and glomerulonephritis. Of these patients, 42% progressed to death and 7% underwent kidney transplantation. The patients on peritoneal dialysis were older and had higher prevalence of diabetes. The death rate varied from 7% among transplanted patients to 45% among non-transplanted patients. In the final Cox proportional hazards model, the risk of mortality was associated with increasing age, female sex, having diabetes, living in the North and Northeast region, peritoneal dialysis as a first modality and not having renal transplantation. CONCLUSIONS: There was an increased prevalence of patients on renal therapy in Brazil. Increased risk of death was associated with advanced age, diabetes, the female sex, residents of the North and Northeast region and lack of renal transplant.", 
+                        "l": "en",
+                        "_": ""
+                    },
+                    {
+                        "a": "OBJETIVO: Describir el perfil epidemiol\u00f3gico y cl\u00ednico de pacientes en terapia renal substitutiva, identificando factores asociados al riesgo de muerte. M\u00c9TODOS: Estudio de observaci\u00f3n, prospectivo no concurrente, a partir de datos de 90.356 pacientes de la Base Nacional en Terapias Renales Substitutivas, en Brasil. Fue realizado reracionamiento determin\u00edstico-probabil\u00edstico del Sistema de Informaci\u00f3n de Mortalidad. Fueron incluidos todos los pacientes incidentes que iniciaron di\u00e1lisis entre 1/1/2000 y 31/12/2004, acompa\u00f1ados hasta la muerte o final de 2004. Edad, sexo, regi\u00f3n de residencia, enfermedad renal primaria, causa del \u00f3bito fueron analizados. Se ajust\u00f3 un modelo de riesgos proporcionales para identificar factores asociados al riesgo de muerte. RESULTADOS: Ocurri\u00f3 un aumento promedio de 5,5% en la prevalencia de pacientes en terapia, con relaci\u00f3n a la incidencia se mantuvo estable en el per\u00edodo. Hemodi\u00e1lisis fue la modalidad inicial predominante (89%). La mayor\u00eda de los pacientes era del sexo masculino, con edad promedio de 53 a\u00f1os, residente en la regi\u00f3n Sureste y presentaba causa indeterminada como principal causa b\u00e1sica de la enfermedad renal cr\u00f3nica, seguida de la hipertensi\u00f3n, diabetes y glomerulonefritis. De esos pacientes, 7% realizaron transplante renal y 42% evolucionaron a \u00f3bito. Los pacientes en di\u00e1lisis peritoneal eran m\u00e1s ancianos y presentaban mayor prevalencia de diabetes. Entre los no transplantados, 45% fueron a \u00f3bito y, entre los transplantadas 7%. En el modelo final de riesgos proporcionales de Cox, el riesgo de mortalidad estuvo asociado con el aumento de la edad, sexo femenino, tener diabetes, residir en la regi\u00f3n Norte y Noreste, di\u00e1lisis peritoneal como modalidad de entrada y no haber realizado transplante renal. CONCLUSIONES: Hubo aumento de la prevalencia de pacientes en terapia renal en Brasil. Pacientes con edad avanzada, diabetes, del sexo femenino, residentes en la regi\u00f3n Norte y Noreste y sin transplante renal presentan mayor riesgo de muerte.", 
+                        "l": "es",
+                        "_": ""
+                    }
+                ]
+            },
+            "citations": [
+                {
+                    "v30": [
+                        {
+                            "_": "Ethn Dis."
+                        }
+                    ],
+                    "v31": [
+                        {
+                            "_": "16"
+                        }
+                    ],
+                    "v32": [
+                        {
+                            "s": "2",
+                            "_": "2"
+                        }
+                    ],
+                    "v118": [
+                        {
+                            "_": "1"
+                        }
+                    ],
+                    "v12": [
+                        {
+                            "l": "en",
+                            "_": "End-stage renal disease in sub-Saharan Africa."
+                        }
+                    ],
+                    "v65": [
+                        {
+                            "_": "20060000"
+                        }
+                    ],
+                    "v64": [
+                        {
+                            "_": "2006"
+                        }
+                    ],
+                    "v14": [
+                        {
+                            "_": "2,5,9"
+                        }
+                    ],
+                    "v880": [
+                        {
+                            "_": "S0034-8910201000040000700001"
+                        }
+                    ],
+                    "v701": [
+                        {
+                            "_": "1"
+                        }
+                    ],
+                    "v865": [
+                        {
+                            "_": "20100800"
+                        }
+                    ],
+                    "v702": [
+                        {
+                            "_": "V:\\Scielo\\serial\\rsp\\v44n4\\markup\\07.htm"
+                        }
+                    ],
+                    "v10": [
+                        {
+                            "s": "Bamgboye",
+                            "r": "ND",
+                            "_": "",
+                            "n": "EL"
+                        }
+                    ]
+                },
+            ]
+        }
+        self._article = Article(article_json)
+
+    def test_journal_article_element(self):
+        xmlcrossref = ET.Element('doi_batch')
+        body = ET.Element('body')
+        body.append(ET.Element('journal'))
+        xmlcrossref.append(body)
+
+        data = [self._article, xmlcrossref]
+
+        xmlcrossref = export_crossref.XMLJournalArticlePipe()
+        raw, xml = xmlcrossref.transform(data)
+
+        langs = ['pt', 'en', 'es']
+        self.assertEqual(len(xml.findall('.//journal_article')), 3)
+        for ja, lang in zip(
+                xml.findall('.//journal_article'), langs):
+            with self.subTest(lang):
+                self.assertEqual(ja.get('language'), lang)
+
+    def test_article_titles_element(self):
+        xmlcrossref = create_xmlcrossref_with_n_journal_article_element(
+            self._article.text_langs)
+
+        data = [self._article, xmlcrossref]
+
+        xmlcrossref = export_crossref.XMLArticleTitlesPipe()
+        raw, xml = xmlcrossref.transform(data)
+
+        self.assertEqual(len(xml.findall('.//journal_article/titles')), 3)
+
+    def test_article_title_element(self):
+        xmlcrossref = create_xmlcrossref_with_n_journal_article_element(
+            self._article.text_langs, 'titles')
+
+        data = [self._article, xmlcrossref]
+
+        xmlcrossref = export_crossref.XMLArticleTitlePipe()
+        raw, xml = xmlcrossref.transform(data)
+
+        expected_content = [
+            ('Perfil epidemiológico dos pacientes em terapia renal'
+             ' substitutiva no Brasil, 2000-2004', None, None),
+            ('Epidemiological profile of patients on'
+             ' renal replacement therapy in Brazil, 2000-2004', 'pt',
+             'Perfil epidemiológico dos pacientes em terapia renal'
+             ' substitutiva no Brasil, 2000-2004'),
+            ('Perfil epidemiológico de los pacientes en terapia'
+             ' renal substitutiva en Brasil, 2000-2004', 'pt',
+             'Perfil epidemiológico dos pacientes em terapia renal'
+             ' substitutiva no Brasil, 2000-2004'),
+        ]
+        self.assertEqual(len(xml.findall('.//titles')), 3)
+        for titles, content in zip(xml.findall('.//titles'), expected_content):
+            with self.subTest(content[0]):
+                self.assertEqual(
+                    titles.findtext('title'), content[0])
+                self.assertEqual(
+                    titles.findtext('original_language_title'), content[2])
+                lang = titles.find('original_language_title')
+                if lang is not None:
+                    lang = lang.attrib.get('language')
+                self.assertEqual(lang, content[1])
+
+    def test_article_contributors_element(self):
+        xmlcrossref = create_xmlcrossref_with_n_journal_article_element(
+            self._article.text_langs)
+
+        data = [self._article, xmlcrossref]
+
+        xmlcrossref = export_crossref.XMLArticleContributorsPipe()
+        raw, xml = xmlcrossref.transform(data)
+
+        self.assertEqual(
+            3, len(xml.findall('.//journal_article')))
+        self.assertEqual(
+            3, len(xml.findall('.//journal_article/contributors')))
+
+    def test_article_publication_date_element(self):
+        xmlcrossref = create_xmlcrossref_with_n_journal_article_element(
+            self._article.text_langs)
+
+        data = [self._article, xmlcrossref]
+
+        xmlcrossref = export_crossref.XMLArticlePubDatePipe()
+        raw, xml = xmlcrossref.transform(data)
+
+        expected = b"""<doi_batch><body><journal>
+            <journal_article publication_type="full_text">
+                <publication_date media_type="online">
+                    <month>08</month>
+                    <year>2010</year></publication_date></journal_article>
+            <journal_article publication_type="full_text">
+                <publication_date media_type="online">
+                    <month>08</month>
+                    <year>2010</year></publication_date></journal_article>
+            <journal_article publication_type="full_text">
+                <publication_date media_type="online">
+                    <month>08</month>
+                    <year>2010</year></publication_date></journal_article>
+            </journal></body></doi_batch>"""
+
+        for i, pubdate in enumerate(
+                xml.findall('.//journal_article//publication_date')):
+            with self.subTest(label=i):
+                self.assertEqual(pubdate.findtext('year'), '2010')
+                self.assertEqual(pubdate.findtext('month'), '08')
+                self.assertEqual(pubdate.findtext('data'), None)
+
+    def test_article_pages_element(self):
+        xmlcrossref = create_xmlcrossref_with_n_journal_article_element(
+            self._article.text_langs)
+
+        data = [self._article, xmlcrossref]
+
+        xmlcrossref = export_crossref.XMLPagesPipe()
+        raw, xml = xmlcrossref.transform(data)
+
+        for i, node in enumerate(
+                xml.findall('.//journal_article//pages')):
+            with self.subTest(label=i):
+                self.assertEqual(node.findtext('first_page'), '14')
+                self.assertEqual(node.findtext('last_page'), '20')
+
+    def test_article_pid_element(self):
+        xmlcrossref = create_xmlcrossref_with_n_journal_article_element(
+            self._article.text_langs)
+
+        data = [self._article, xmlcrossref]
+
+        xmlcrossref = export_crossref.XMLPIDPipe()
+        raw, xml = xmlcrossref.transform(data)
+
+        for i, node in enumerate(
+                xml.findall('.//journal_article//publisher_item')):
+            with self.subTest(label=i):
+                self.assertEqual(
+                    node.findtext('identifier'),
+                    'S0034-89102010000400007')
+
+    def test_doi_data_elem_for_multilingue_document(self):
+        xmlcrossref = create_xmlcrossref_with_n_journal_article_element(
+            self._article.text_langs)
+
+        data = [self._article, xmlcrossref]
+        xmlcrossref = export_crossref.XMLDOIDataPipe()
+        raw, xml = xmlcrossref.transform(data)
+
+        self.assertEqual(
+            3, len(xml.findall('.//journal_article')))
+        self.assertEqual(
+            3, len(xml.findall('.//doi_data')))
+
+    def test_doi_elem_for_multilingue_document(self):
+        xmlcrossref = create_xmlcrossref_with_n_journal_article_element(
+            self._article.text_langs, 'doi_data')
+
+        data = [self._article, xmlcrossref]
+        xmlcrossref = export_crossref.XMLDOIPipe()
+        raw, xml = xmlcrossref.transform(data)
+
+        expected_content = [
+            ('10.1590/S0034-89102010000400007', 0),
+            ('10.1590/ID.en', 1),
+            ('10.1590/ID.es', 2),
+        ]
+        self.assertEqual(
+            3, len(xml.findall('.//journal_article')))
+        self.assertEqual(
+            3, len(xml.findall('.//doi_data/doi')))
+
+        for doi, content in zip(
+                xml.findall('.//doi_data/doi'), expected_content):
+            with self.subTest(label=content[1]):
+                self.assertEqual(content[0], doi.text)
+
+    def test_resource_elem_for_multilingue_document(self):
+        xmlcrossref = create_xmlcrossref_with_n_journal_article_element(
+            self._article.text_langs, 'doi_data')
+
+        data = [self._article, xmlcrossref]
+        xmlcrossref = export_crossref.XMLResourcePipe()
+        raw, xml = xmlcrossref.transform(data)
+
+        expected_content = [
+            ("http://www.scielo.br/scielo.php?"
+                "script=sci_arttext&pid="
+             "S0034-89102010000400007&tlng=pt", 0),
+            ("http://www.scielo.br/scielo.php?"
+                "script=sci_arttext&pid="
+             "S0034-89102010000400007&tlng=en", 1),
+            ("http://www.scielo.br/scielo.php?"
+                "script=sci_arttext&pid="
+             "S0034-89102010000400007&tlng=es", 2),
+        ]
+        self.assertEqual(
+            3, len(xml.findall('.//journal_article')))
+        self.assertEqual(
+            3, len(xml.findall('.//doi_data/resource')))
+
+        for resource, content in zip(
+                xml.findall('.//doi_data/resource'), expected_content):
+            with self.subTest(label=content[1]):
+                self.assertEqual(content[0], resource.text)
+
+    def test_article_abstracts_elem_for_multilingue_document(self):
+        xmlcrossref = create_xmlcrossref_with_n_journal_article_element(
+            self._article.text_langs, 'doi_data')
+
+        data = [self._article, xmlcrossref]
+        xmlcrossref = export_crossref.XMLArticleAbstractPipe()
+        raw, xml = xmlcrossref.transform(data)
+
+        abstracts = [raw.original_abstract()]
+        abstracts.append("OBJECTIVE: To describe the clinical and epidemiological profile of patients under renal replacement therapies, identifying risk factors for death. METHODS: This is a non-concurrent cohort study of data for 90,356 patients in the National Renal Replacement Therapies Database. A deterministic-probabilistic linkage was performed using the Authorization System for High Complexity/Cost Procedures and the Mortality Information System databases. All patients who started dialysis between 1/1/2000 and 12/31/2004 were included and followed until death or the end of 2004. Age, sex, region of residence, primary renal disease and causes of death were analyzed. A proportional hazards model was used to identify factors associated with risk of death. RESULTS: The prevalence of patients under renal replacement therapies increased an average of 5.5%, while incidence remained stable during the period. Hemodialysis was the predominant initial modality (89%). The patients were majority male with mean age 53 years, residents of the Southeast region and presented unknown causes as the main cause of chronic renal disease, followed by hypertension, diabetes and glomerulonephritis. Of these patients, 42% progressed to death and 7% underwent kidney transplantation. The patients on peritoneal dialysis were older and had higher prevalence of diabetes. The death rate varied from 7% among transplanted patients to 45% among non-transplanted patients. In the final Cox proportional hazards model, the risk of mortality was associated with increasing age, female sex, having diabetes, living in the North and Northeast region, peritoneal dialysis as a first modality and not having renal transplantation. CONCLUSIONS: There was an increased prevalence of patients on renal therapy in Brazil. Increased risk of death was associated with advanced age, diabetes, the female sex, residents of the North and Northeast region and lack of renal transplant.")
+        abstracts.append("OBJETIVO: Describir el perfil epidemiol\u00f3gico y cl\u00ednico de pacientes en terapia renal substitutiva, identificando factores asociados al riesgo de muerte. M\u00c9TODOS: Estudio de observaci\u00f3n, prospectivo no concurrente, a partir de datos de 90.356 pacientes de la Base Nacional en Terapias Renales Substitutivas, en Brasil. Fue realizado reracionamiento determin\u00edstico-probabil\u00edstico del Sistema de Informaci\u00f3n de Mortalidad. Fueron incluidos todos los pacientes incidentes que iniciaron di\u00e1lisis entre 1/1/2000 y 31/12/2004, acompa\u00f1ados hasta la muerte o final de 2004. Edad, sexo, regi\u00f3n de residencia, enfermedad renal primaria, causa del \u00f3bito fueron analizados. Se ajust\u00f3 un modelo de riesgos proporcionales para identificar factores asociados al riesgo de muerte. RESULTADOS: Ocurri\u00f3 un aumento promedio de 5,5% en la prevalencia de pacientes en terapia, con relaci\u00f3n a la incidencia se mantuvo estable en el per\u00edodo. Hemodi\u00e1lisis fue la modalidad inicial predominante (89%). La mayor\u00eda de los pacientes era del sexo masculino, con edad promedio de 53 a\u00f1os, residente en la regi\u00f3n Sureste y presentaba causa indeterminada como principal causa b\u00e1sica de la enfermedad renal cr\u00f3nica, seguida de la hipertensi\u00f3n, diabetes y glomerulonefritis. De esos pacientes, 7% realizaron transplante renal y 42% evolucionaron a \u00f3bito. Los pacientes en di\u00e1lisis peritoneal eran m\u00e1s ancianos y presentaban mayor prevalencia de diabetes. Entre los no transplantados, 45% fueron a \u00f3bito y, entre los transplantadas 7%. En el modelo final de riesgos proporcionales de Cox, el riesgo de mortalidad estuvo asociado con el aumento de la edad, sexo femenino, tener diabetes, residir en la regi\u00f3n Norte y Noreste, di\u00e1lisis peritoneal como modalidad de entrada y no haber realizado transplante renal. CONCLUSIONES: Hubo aumento de la prevalencia de pacientes en terapia renal en Brasil. Pacientes con edad avanzada, diabetes, del sexo femenino, residentes en la regi\u00f3n Norte y Noreste y sin transplante renal presentan mayor riesgo de muerte.")
+
+        abstract_nodes = xml.findall(
+            './/{http://www.ncbi.nlm.nih.gov/JATS1}abstract/{http://www.ncbi.nlm.nih.gov/JATS1}p')
+        self.assertEqual(3, len(xml.findall('.//journal_article')))
+        self.assertEqual(9, len(abstract_nodes))
+
+        xml_abstracts = [a.text for a in abstract_nodes]
+        self.assertEqual(abstracts * 3, xml_abstracts)
+
+    def test_related_item_for_multilingue_document(self):
+        xmlcrossref = create_xmlcrossref_with_n_journal_article_element(
+            self._article.text_langs)
+
+        data = [self._article, xmlcrossref]
+        xmlcrossref = export_crossref.XMLProgramPipe()
+        raw, xml = xmlcrossref.transform(data)
+
+        expected_content = [
+            ('10.1590/ID.en',
+             "Epidemiological profile of patients on"
+             " renal replacement therapy in Brazil, 2000-2004",
+             0
+             ),
+            ('10.1590/ID.es',
+             "Perfil epidemiológico de los pacientes en terapia"
+             " renal substitutiva en Brasil, 2000-2004",
+             1
+             ),
+            ('10.1590/S0034-89102010000400007',
+             "Perfil epidemiológico dos pacientes em terapia"
+             " renal substitutiva no Brasil, 2000-2004",
+             2
+             ),
+            ('10.1590/S0034-89102010000400007',
+             "Perfil epidemiológico dos pacientes em terapia"
+             " renal substitutiva no Brasil, 2000-2004",
+             3
+             ),
+        ]
+        self.assertEqual(
+            3, len(xml.findall('.//program')))
+        self.assertEqual(
+            4, len(xml.findall('.//program/related_item/intra_work_relation')))
+        self.assertEqual(
+            4, len(xml.findall('.//program/related_item/description')))
+
+        for related_item, content in zip(
+                xml.findall('.//program/related_item'), expected_content):
+            with self.subTest(label=content[2]):
+                self.assertEqual(
+                    content[1], related_item.findtext('description'))
+                intra_work_relation = related_item.find('intra_work_relation')
+                self.assertEqual(
+                    content[0], intra_work_relation.text)
+                self.assertEqual(
+                    'doi', intra_work_relation.attrib.get('identifier-type'))
+                self.assertEqual(
+                    'isTranslationOf',
+                    intra_work_relation.attrib.get('relationship-type'))
+
+    def test_collection_for_multilingue_document(self):
+        xmlcrossref = create_xmlcrossref_with_n_journal_article_element(
+            self._article.text_langs, 'doi_data')
+
+        data = [self._article, xmlcrossref]
+        xmlcrossref = export_crossref.XMLCollectionPipe()
+        raw, xml = xmlcrossref.transform(data)
+
+        texts = [
+            "http://www.scielo.br/pdf/rsp/v44n4/07.pdf",
+            "http://www.scielo.br/pdf/rsp/v44n4/en_07.pdf",
+            "http://www.scielo.br/pdf/rsp/v44n4/es_07.pdf",
+        ]
+        self.assertEqual(
+            3, len(xml.findall('.//doi_data//collection')))
+        for res, text in zip(
+                xml.findall('.//doi_data/collection/item/resource'), texts):
+            with self.subTest(text):
+                self.assertEqual(res.text, text)
+
+    def test_citations_for_multilingue_document(self):
+        xmlcrossref = create_xmlcrossref_with_n_journal_article_element(
+            self._article.text_langs)
+
+        data = [self._article, xmlcrossref]
+        xmlcrossref = export_crossref.XMLArticleCitationsPipe()
+        raw, xml = xmlcrossref.transform(data)
+        self.assertEqual(
+            3, len(xml.findall('.//journal_article//citation_list')))


### PR DESCRIPTION
#### O que esse PR faz?
No XML do CrossRef incluir um DOI para cada versão de idioma do documento. 
Para resolver, as mudanças no XML que foram feitas são:

1. Onde havia apenas 1 ``journal_article`` por documento fica 1 ``journal_article`` para cada idioma de texto disponível.
2. Dentro do elemento ``journal_article/titles``, incluir o elemento ``original_language_title``.
Exemplo:
```xml
<titles>
     <title>TÍTULO DO ARTIGO (VERSÃO TRADUÇÃO)</title>
     <original_language_title language="en">An article in its original language which happens to be English</original_language_title>
</titles>
```
3. Incluir um novo elemento related_item:
```xml
<program xmlns="http://www.crossref.org/relations.xsd">
     <related_item>
       <description>DOCUMENTO NA VERSÃO ORIGINAL</description>
       <intra_work_relation relationship-type="isTranslationOf" identifier-type="doi">10.5555/original_language</intra_work_relation>
     </related_item>
</program>
```
4. No elemento ``doi_data/doi`` de cada ``journal_article`` estará o DOI correspondente ao idioma
```xml
<doi_data>
     <doi>10.5555/translation</doi>
     <resource>http://www.crossref.org/</resource>
</doi_data>
```
5. No elemento ``doi_data/collection/item/resource`` de cada ``journal_article`` estará o endereço do PDF correspondente ao idioma
```xml
<doi_data>
	<doi>10.1590/1518-8345.2608.3086</doi>
	<resource>http://www.scielo.br/scielo.php?script=sci_arttext&amp;pid=S0104-11692019000100300&amp;lng=en&amp;tlng=en</resource>
	<collection property="crawler-based">
  	    <item crawler="iParadigms">
	        <resource>http://www.scielo.br/pdf/rlae/v27/0104-1169-rlae-27-e3086.pdf</resource>
	    </item>
	</collection>
</doi_data>
```
6. Todos os demais elementos serão **cópias** em cada ``journal_article``.

#### Onde a revisão poderia começar?
- articlemeta/articlemeta.py:292
- articlemeta/export_crossref.py
-  tests/test_export_crossref.py

#### Como este poderia ser testado manualmente?
``python setup.py test``

#### Algum cenário de contexto que queira dar?
O atributo ``Article.doi_and_lang`` (xylose) fornece DOI encontrados no Documento. No entanto, caso o Documento tenha as traduções mas sem DOI, é configurável que seja gerado os DOI para as traduções seguindo o padrão ``DOI.<idioma>``, exemplo: ``10.1590/doidoartigo.en``
O parâmetro é ``doi_for_translation`` com valores: ``derivate`` (derivar) ou ``provided`` (usar o fornecido). O default é ``derivate``.
Esta abordagem foi tratada dentro de ``export.py`` na classe ``CustomArticle`` no atributo ``document_doi_and_lang``

### Screenshots
Exemplo de XML da tradução
```xml
...
<journal_article publication_type="full_text">
  <titles>
     <title>TÍTULO DO ARTIGO (VERSÃO TRADUÇÃO)</title>
     <original_language_title language="en">An article in its original language which happens to be English</original_language_title>
   </titles>
   <contributors>
     <person_name sequence="first" contributor_role="author">
       <given_name>Daniel</given_name>
       <surname>Stepputtis</surname>
       <ORCID authenticated="true">http://orcid.org/0000-0003-4824-1631</ORCID>
     </person_name>
  </contributors>
  <publication_date media_type="online">
     <month>02</month>
     <day>28</day>
     <year>2013</year>
  </publication_date>
  <program xmlns="http://www.crossref.org/relations.xsd">
     <related_item>
       <description>DOCUMENTO NA VERSÃO ORIGINAL</description>
       <intra_work_relation relationship-type="isTranslationOf" identifier-type="doi">10.5555/original_language</intra_work_relation>
     </related_item>
  </program>
  <doi_data>
     <doi>10.5555/translation</doi>
     <resource>http://www.crossref.org/</resource>
  </doi_data>
</journal_article>
```

#### Quais são tickets relevantes?
#161

### Referências
- https://support.crossref.org/hc/en-us/articles/214357426-Relationships-between-DOIs-and-other-objects
- exemplos fornecidos pelo contato do crossref (pfeeney): [rescielodoiformultilingualarticles(1).zip](https://github.com/scieloorg/articles_meta/files/3022118/rescielodoiformultilingualarticles.1.zip)
- exemplo de XML retornado pelo ArticleMeta: http://articlemeta.scielo.org/api/v1/article/?collection=scl&code=S0104-11692019000100300&format=xmlcrossref
- ver mais em #161

