### PR TITLE
Corrige testes após atualizacao de xylose para 1.35.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
     ],
     dependency_links=[
         "git+https://github.com/scieloorg/thriftpy-wrap@0.1.1#egg=thriftpywrap",
-        "git+https://github.com/scieloorg/xylose.git@1.35.3#egg=xylose",
+        "git+https://github.com/scieloorg/xylose.git@1.35.4#egg=xylose",
     ],
     include_package_data=True,
     zip_safe=False,

--- a/tests/test_export_crossref.py
+++ b/tests/test_export_crossref.py
@@ -775,7 +775,7 @@ class ExportCrossRef_MultiLingueDoc_with_MultipleDOI_Tests(unittest.TestCase):
                 xml.findall('.//journal_article//publication_date')):
             with self.subTest(label=i):
                 self.assertEqual(pubdate.findtext('year'), '2010')
-                self.assertEqual(pubdate.findtext('month'), '08')
+                self.assertEqual(pubdate.findtext('month'), None)
                 self.assertEqual(pubdate.findtext('data'), None)
 
     def test_article_pages_element(self):
@@ -1256,7 +1256,7 @@ class ExportCrossRef_MultiLingueDoc_with_DOI_pt_es_Tests(unittest.TestCase):
                 xml.findall('.//journal_article//publication_date')):
             with self.subTest(label=i):
                 self.assertEqual(pubdate.findtext('year'), '2010')
-                self.assertEqual(pubdate.findtext('month'), '08')
+                self.assertEqual(pubdate.findtext('month'), None)
                 self.assertEqual(pubdate.findtext('data'), None)
 
     def test_article_pages_element(self):


### PR DESCRIPTION
#### O que esse PR faz?
Corrige testes que usam **Article.publication_date** do **xylose**. Como houve correção neste atributo, o resultado é diferente do esperado e os testes quebraram no articles_meta, ao gerar XML do CrossRef.

#### Onde a revisão poderia começar?
-  tests/test_export_crossref.py

#### Como este poderia ser testado manualmente?
``python setup.py test -s tests/test_export_crossref.py``

#### Algum cenário de contexto que queira dar?
Escrevi um email para o contato do CrossRef pedindo orientação a respeito de como enviaremos a data, já que há caso que temos a data do artigo e a data do fascículo. Devemos enviar as duas? ou somente a do fascículo? Por não saber ainda esta resposta, apenas corrigi os testes. Após ter a orientação do CrossRef, devemos verificar se **XMLArticlePubDatePipe.transform()** atende.

### Screenshots
N/A

#### Quais são tickets relevantes?
N/A

### Referências

https://github.com/scieloorg/xylose/pull/176

