### PR TITLE
Adiciona o `elocation-id` aos metadados do crossref

### DIFF
--- a/articlemeta/export.py
+++ b/articlemeta/export.py
@@ -205,6 +205,7 @@ class Export(object):
             export_crossref.XMLArticleAbstractPipe(),
             export_crossref.XMLArticlePubDatePipe(),
             export_crossref.XMLPagesPipe(),
+            export_crossref.XMLElocationPipe(),
             export_crossref.XMLPIDPipe(),
             export_crossref.XMLDOIDataPipe(),
             export_crossref.XMLDOIPipe(),

--- a/articlemeta/export_crossref.py
+++ b/articlemeta/export_crossref.py
@@ -540,6 +540,28 @@ class XMLPagesPipe(plumber.Pipe):
         return data
 
 
+class XMLElocationPipe(plumber.Pipe):
+    """Pipeline que verifica a exisência do elocation-id (v14)
+    e o adiciona no XML de formato crossref"""
+
+    def precond(data):
+        raw, _ = data
+
+        if not raw.elocation:
+            raise plumber.UnmetPrecondition()
+
+    @plumber.precondition(precond)
+    def transform(self, data):
+        raw, xml = data
+
+        elocation_id = ET.Element("elocation-id")
+        elocation_id.text = raw.elocation
+
+        for journal_article in xml.findall("./body/journal//journal_article"):
+            journal_article.append(deepcopy(elocation_id))
+
+        return data
+
 class XMLPIDPipe(plumber.Pipe):
 
     def transform(self, data):

--- a/tests/test_export_crossref.py
+++ b/tests/test_export_crossref.py
@@ -472,6 +472,54 @@ class ExportCrossRef_one_DOI_only_Tests(unittest.TestCase):
         self.assertTrue(schema.validate(xmlio))
         self.assertEqual(None, schema.assertValid(xmlio))
 
+    def test_article_should_has_elocation_id(self):
+        self._article_meta.data['article']['v14'][0]['e'] = 'e2'
+        xmlcrossref = ET.Element("doi_batch")
+
+        journal_article = ET.Element("journal_article")
+        journal_article.set("publication_type", "full_text")
+
+        journal = ET.Element("journal")
+        journal.append(journal_article)
+
+        body = ET.Element("body")
+        body.append(journal)
+
+        xmlcrossref.append(body)
+
+        data = [self._article_meta, xmlcrossref]
+
+        xmlcrossref = export_crossref.XMLElocationPipe()
+        _, xml = xmlcrossref.transform(data)
+        self.assertEqual(
+            b'<doi_batch><body><journal><journal_article publication_type="full_text"><elocation-id>e2</elocation-id></journal_article></journal></body></doi_batch>',
+            ET.tostring(xml),
+        )
+
+    def test_article_should_has_not_elocation_id(self):
+        xmlcrossref = ET.Element("doi_batch")
+
+        journal_article = ET.Element("journal_article")
+        journal_article.set("publication_type", "full_text")
+
+        journal = ET.Element("journal")
+        journal.append(journal_article)
+
+        body = ET.Element("body")
+        body.append(journal)
+
+        xmlcrossref.append(body)
+
+        data = [self._article_meta, xmlcrossref]
+
+        xmlcrossref = export_crossref.XMLElocationPipe()
+        _, xml = xmlcrossref.transform(data)
+
+        self.assertEqual(
+            b'<doi_batch><body><journal><journal_article publication_type="full_text"/></journal></body></doi_batch>',
+            ET.tostring(xml),
+        )
+
 
 class ExportCrossRef_MultiLingueDoc_with_MultipleDOI_Tests(unittest.TestCase):
 


### PR DESCRIPTION
#### O que esse PR faz?
Este pull request adiciona o campo `elocation-id` aos metadados do artigo quando o mesmo é exportado para o formato `xmlcrossref`.

#### Onde a revisão poderia começar?
- `articlemeta/export.py` L: `208`
- `articlemeta/export_crossref.py` L: `543`

#### Como este poderia ser testado manualmente?
Para testar manualmente este pr deve-se:
- Iniciar o articlemeta
- Verificar um artigo que contenha o valor do elocation-id (ex: `/api/v1/article/?code=S2179-975X2019000100301&format=xmlcrossref`)
- Verificar um artigo que não contenha o valor do elocation-id (ex: `/api/v1/article/?code=S2179-975X2011000300002&format=xmlcrossref`)
- Verificar a existência do dado em outros formatos (ex: `xmlrsps`)

#### Algum cenário de contexto que queira dar?
N/A

### Screenshots
N/A

#### Quais são os tickets relevantes?
#167

### Referências
http://data.crossref.org/reports/help/schema_doc/4.4.0/4.4.0.html
