### PR TITLE
Altera exportação de Contribuidores para o CrossRef

### DIFF
--- a/articlemeta/articlemeta.py
+++ b/articlemeta/articlemeta.py
@@ -317,7 +317,8 @@ def get_article(request):
 
         if fmt == 'xmlcrossref':
             return Response(
-                Export(article).pipeline_crossref(), content_type="application/xml")
+                Export(article).pipeline_crossref(request.databroker.is_name_suffix),
+                content_type="application/xml")
 
         if fmt == 'opac':
             return Export(article).pipeline_opac()

--- a/articlemeta/controller.py
+++ b/articlemeta/controller.py
@@ -123,7 +123,10 @@ def get_dbconn(db_dsn):
                 [[('version', pymongo.ASCENDING)], {'background': True}],
                 [[('code', pymongo.ASCENDING), ('collection',  pymongo.ASCENDING)], {'unique': True, 'background': True}],
                 [[('collection', pymongo.ASCENDING), ('processing_date',  pymongo.ASCENDING)], {'background': True}]
-            ]
+            ],
+            'name_suffixes': [
+                [[('suffix', pymongo.ASCENDING)], {'background': True}],
+            ],
         }
 
         for collection, indexes in index_by_collection.items():
@@ -1262,3 +1265,16 @@ class DataBroker(object):
     def get_issue_code_from_label(self, label, journal_code, collection):
         return self.issuemeta.get_code_from_label(label=label,
                 journal_code=journal_code, collection=collection)
+
+    def is_name_suffix(self, suffix):
+        if suffix.endswith('.'):
+            suffix = suffix[:-1]
+        result = self.db['name_suffixes'].find_one({'suffix': suffix.lower()})
+        return True if result is not None else False
+
+    def add_name_suffix(self, metadata):
+        suffix_data = {'suffix': metadata["suffix"]}
+        if self.db['name_suffixes'].find(suffix_data).count() < 1:
+            self.db['name_suffixes'].update_one(
+                suffix_data, {'$set': suffix_data}, upsert=True
+            )

--- a/articlemeta/export.py
+++ b/articlemeta/export.py
@@ -12,12 +12,22 @@ from articlemeta import export_crossref
 
 
 class CustomArticle(Article):
+
+    def __init__(self, data, fnc_is_name_suffix=None):
+        super().__init__(data)
+        self.fnc_is_name_suffix = fnc_is_name_suffix
+
     @property
     def issue_publication_date(self):
         if 'v65' in self.data['article']:
             return xylose.tools.get_date(self.data['article']['v65'][0]['_'])
         else:
             return None
+
+    def is_name_suffix(self, suffix):
+        if self.fnc_is_name_suffix is not None:
+            return self.fnc_is_name_suffix(suffix)
+        return False
 
 
 class JournalExport:
@@ -178,8 +188,8 @@ class Export(object):
 
         return next(transformed_data)
 
-    def pipeline_crossref(self):
-        xylose_article = CustomArticle(self._article)
+    def pipeline_crossref(self, fnc_is_name_suffix):
+        xylose_article = CustomArticle(self._article, fnc_is_name_suffix)
 
         ppl = plumber.Pipeline(
             export_crossref.SetupDoiBatchPipe(),

--- a/articlemeta/export_crossref.py
+++ b/articlemeta/export_crossref.py
@@ -376,7 +376,6 @@ class XMLArticleContributorsPipe(plumber.Pipe):
         raw, xml = data
 
         el = ET.Element('contributors')
-
         for ndx, authors in enumerate(raw.authors):
             author = ET.Element('person_name')
             author.set('contributor_role', 'author')
@@ -392,8 +391,17 @@ class XMLArticleContributorsPipe(plumber.Pipe):
 
             if 'surname' in authors and authors['surname']:
                 lastname = ET.Element('surname')
-                lastname.text = authors['surname']
-                author.append(lastname)
+                author_surname = authors['surname'].split()
+                if len(author_surname) > 1 and \
+                        raw.is_name_suffix(author_surname[-1]): # ver export.CustomArticle
+                    suffix = ET.Element('suffix')
+                    suffix.text = author_surname[-1]
+                    lastname.text = " ".join(author_surname[:-1])
+                    author.append(lastname)
+                    author.append(suffix)
+                else:
+                    lastname.text = authors['surname']
+                    author.append(lastname)
 
             author_index = [i.upper() for i in authors.get('xref', []) or []]
 

--- a/articlemeta/thrift/articlemeta.thrift
+++ b/articlemeta/thrift/articlemeta.thrift
@@ -85,11 +85,13 @@ service ArticleMeta {
     bool exists_article(1: string code, 2: string collection) throws (1: ValueError value_err, 2:ServerError server_err),
     bool exists_issue(1: string code, 2: string collection) throws (1: ValueError value_err, 2:ServerError server_err),
     bool exists_journal(1: string code, 2: string collection) throws (1: ValueError value_err, 2:ServerError server_err),
+    bool is_name_suffix(1: string suffix) throws (1: ValueError value_err, 2:ServerError server_err),
     string delete_journal(1: string code, 2: string collection, 3: string admintoken) throws (1:ServerError server_err, 2:Unauthorized unauthorized_access),
     string delete_issue(1: string code, 2: string collection, 3: string admintoken) throws (1:ServerError server_err, 2:Unauthorized unauthorized_access),
     string delete_article(1: string code, 2: string collection, 3: string admintoken) throws (1:ServerError server_err, 2:Unauthorized unauthorized_access),
     string add_journal(1: string metadata, 2: string admintoken) throws (1: ValueError value_err, 2:ServerError server_err, 3:Unauthorized unauthorized_access),
     string add_issue(1: string metadata, 2: string admintoken) throws (1: ValueError value_err, 2:ServerError server_err, 3:Unauthorized unauthorized_access),
     string add_article(1: string metadata, 2: string admintoken) throws (1: ValueError value_err, 2:ServerError server_err, 3:Unauthorized unauthorized_access),
+    void add_name_suffix(1: string metadata, 2: string admintoken) throws (1: ValueError value_err, 2:ServerError server_err, 3:Unauthorized unauthorized_access),
     string get_issue_code_from_label(1: string label, 2: string journal_code, 3: string collection) throws (1: ValueError value_err, 2:ServerError server_err)
 }

--- a/articlemeta/thrift/server.py
+++ b/articlemeta/thrift/server.py
@@ -506,7 +506,8 @@ class Dispatcher(object):
                 return Export(data).pipeline_pubmed()
 
             if fmt == 'xmlcrossref':
-                return Export(data).pipeline_crossref()
+                return Export(data).pipeline_crossref(
+                    self._databroker.is_name_suffix)
 
             if fmt == 'opac':
                 return json.dumps(Export(data).pipeline_opac())
@@ -704,6 +705,38 @@ class Dispatcher(object):
         except:
             raise articlemeta_thrift.ServerError(
                 'Server error: DataBroker.get_issue_code_from_label')
+
+    def is_name_suffix(self, suffix):
+        logger.debug(
+            'AM Thrift - is_name_suffix(suffix=%s)' % suffix
+        )
+
+        try:
+            return self._databroker.is_name_suffix(suffix)
+        except:
+            raise articlemeta_thrift.ServerError(
+                'Server error: DataBroker.is_name_suffix')
+
+        return False
+
+    def add_name_suffix(self, metadata, admintoken):
+        logger.debug(
+            'AM Thrift - add_name_suffix(metadata=%s)' % metadata
+        )
+        if admintoken != self._admintoken:
+            raise articlemeta_thrift.Unauthorized(
+                'Unautorized Access: Invalid admin token')
+        try:
+            jdata = json.loads(metadata)
+        except:
+            raise articlemeta_thrift.ValueError(
+                'Value error: DataBroker.add_name_suffix, Invalid JSON')
+        else:
+            try:
+                self._databroker.add_name_suffix(jdata)
+            except:
+                raise articlemeta_thrift.ServerError(
+                    'Server error: DataBroker.add_name_suffix, Nondata inserted')
 
 
 main = thriftpywrap.ConsoleApp(articlemeta_thrift.ArticleMeta, Dispatcher)

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -1,4 +1,5 @@
 import unittest
+from unittest.mock import patch, MagicMock
 from datetime import datetime
 
 from articlemeta import controller
@@ -49,3 +50,64 @@ class FunctionDatesToStringTests(unittest.TestCase):
         _ = controller.dates_to_string(data)
         self.assertEqual(data, data_copy)
 
+
+class DataBrokerTests(unittest.TestCase):
+    def setUp(self):
+        self.mk_db_suffixes = MagicMock()
+        self.mk_db_suffixes.find_one.return_value = None
+        self.mk_db_client = {
+            'journals': [],
+            'issues': [],
+            'articles': [],
+            'name_suffixes': self.mk_db_suffixes,
+        }
+
+    def test_DataBroker_is_name_suffix_not_found(self):
+        databroker = controller.DataBroker(self.mk_db_client)
+        name_suffix = databroker.is_name_suffix(suffix="jr")
+        self.mk_db_suffixes.find_one.assert_called_once_with({"suffix": "jr"})
+        self.assertFalse(name_suffix)
+
+    def test_DataBroker_is_name_suffix_lower_case_suffix(self):
+        databroker = controller.DataBroker(self.mk_db_client)
+        name_suffix = databroker.is_name_suffix(suffix="JR")
+        self.mk_db_suffixes.find_one.assert_called_once_with({"suffix": "jr"})
+
+    def test_DataBroker_is_name_suffix_without_period(self):
+        databroker = controller.DataBroker(self.mk_db_client)
+        name_suffix = databroker.is_name_suffix(suffix="Jr.")
+        self.mk_db_suffixes.find_one.assert_called_once_with({"suffix": "jr"})
+
+    def test_DataBroker_is_name_suffix_accepts_alphanumeric(self):
+        databroker = controller.DataBroker(self.mk_db_client)
+        name_suffix = databroker.is_name_suffix(suffix="3rd")
+        self.mk_db_suffixes.find_one.assert_called_once_with({"suffix": "3rd"})
+
+    def test_DataBroker_is_name_suffix(self):
+        self.mk_db_suffixes.find_one.return_value = {"suffix": "jr"}
+        self.mk_db_client['name_suffixes'] = self.mk_db_suffixes
+        databroker = controller.DataBroker(self.mk_db_client)
+        name_suffix = databroker.is_name_suffix(suffix="jr")
+        self.assertTrue(name_suffix)
+
+    def test_DataBroker_add_name_suffix_checks_if_suffix_exists(self):
+        self.mk_db_suffixes.find.return_value.count.return_value = 1
+        databroker = controller.DataBroker(self.mk_db_client)
+        databroker.add_name_suffix({"suffix": "jr"})
+        self.mk_db_suffixes.find.assert_called_once_with({"suffix": "jr"})
+
+    def test_DataBroker_add_name_suffix_does_not_add_it_if_suffix_exists(self):
+        self.mk_db_suffixes.find.return_value.count.return_value = 1
+        databroker = controller.DataBroker(self.mk_db_client)
+        databroker.add_name_suffix({"suffix": "jr"})
+        self.mk_db_suffixes.update_one.assert_not_called()
+
+    def test_DataBroker_add_name_suffix_adds_it_if_suffix_does_not_exist(self):
+        self.mk_db_suffixes.find.return_value.count.return_value = 0
+        databroker = controller.DataBroker(self.mk_db_client)
+        databroker.add_name_suffix({"suffix": "jr"})
+        self.mk_db_suffixes.update_one.assert_called_once_with(
+            {"suffix": "jr"},
+            {'$set': {"suffix": "jr"}},
+            upsert=True
+        )

--- a/tests/test_export_crossref.py
+++ b/tests/test_export_crossref.py
@@ -3,6 +3,7 @@ import unittest
 import json
 import os
 import io
+from unittest.mock import Mock
 
 from lxml import etree as ET
 
@@ -358,6 +359,11 @@ class ExportCrossRef_one_DOI_only_Tests(unittest.TestCase):
 
     def test_article_contributors_element(self):
 
+        def mock_is_name_suffix(suffix):
+            if suffix == "Junior":
+                return True
+            return False
+
         xmlcrossref = ET.Element('doi_batch')
 
         journal_article = ET.Element('journal_article')
@@ -371,12 +377,13 @@ class ExportCrossRef_one_DOI_only_Tests(unittest.TestCase):
 
         xmlcrossref.append(body)
 
+        self._article_meta = Article(self._raw_json, mock_is_name_suffix)
         data = [self._article_meta, xmlcrossref]
 
         xmlcrossref = export_crossref.XMLArticleContributorsPipe()
         raw, xml = xmlcrossref.transform(data)
 
-        self.assertEqual(b'<doi_batch><body><journal><journal_article publication_type="full_text"><contributors><person_name contributor_role="author" sequence="first"><given_name>Mariangela Leal</given_name><surname>Cherchiglia</surname><affiliation>Universidade Federal de Minas Gerais,  BRAZIL</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>Elaine Leandro</given_name><surname>Machado</surname><affiliation>Universidade Federal de Minas Gerais,  BRAZIL</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>Daniele Ara&#250;jo Campo</given_name><surname>Szuster</surname><affiliation>Universidade Federal de Minas Gerais,  BRAZIL</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>Eli Iola Gurgel</given_name><surname>Andrade</surname><affiliation>Universidade Federal de Minas Gerais,  BRAZIL</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>Francisco de Assis</given_name><surname>Ac&#250;rcio</surname><affiliation>Universidade Federal de Minas Gerais,  BRAZIL</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>Waleska Teixeira</given_name><surname>Caiaffa</surname><affiliation>Universidade Federal de Minas Gerais,  BRAZIL</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>Ricardo</given_name><surname>Sesso</surname><affiliation>Universidade Federal de S&#227;o Paulo,  BRAZIL</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>Augusto A</given_name><surname>Guerra Junior</surname><affiliation>Universidade Federal de Minas Gerais,  BRAZIL; Universidade Federal de S&#227;o Paulo,  BRAZIL</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>Odilon Vanni de</given_name><surname>Queiroz</surname><affiliation>Universidade Federal de Minas Gerais,  BRAZIL</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>Isabel Cristina</given_name><surname>Gomes</surname><affiliation>Universidade Federal de Minas Gerais,  BRAZIL</affiliation></person_name></contributors></journal_article></journal></body></doi_batch>', ET.tostring(xml))
+        self.assertEqual(b'<doi_batch><body><journal><journal_article publication_type="full_text"><contributors><person_name contributor_role="author" sequence="first"><given_name>Mariangela Leal</given_name><surname>Cherchiglia</surname><affiliation>Universidade Federal de Minas Gerais,  BRAZIL</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>Elaine Leandro</given_name><surname>Machado</surname><affiliation>Universidade Federal de Minas Gerais,  BRAZIL</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>Daniele Ara&#250;jo Campo</given_name><surname>Szuster</surname><affiliation>Universidade Federal de Minas Gerais,  BRAZIL</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>Eli Iola Gurgel</given_name><surname>Andrade</surname><affiliation>Universidade Federal de Minas Gerais,  BRAZIL</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>Francisco de Assis</given_name><surname>Ac&#250;rcio</surname><affiliation>Universidade Federal de Minas Gerais,  BRAZIL</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>Waleska Teixeira</given_name><surname>Caiaffa</surname><affiliation>Universidade Federal de Minas Gerais,  BRAZIL</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>Ricardo</given_name><surname>Sesso</surname><affiliation>Universidade Federal de S&#227;o Paulo,  BRAZIL</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>Augusto A</given_name><surname>Guerra</surname><suffix>Junior</suffix><affiliation>Universidade Federal de Minas Gerais,  BRAZIL; Universidade Federal de S&#227;o Paulo,  BRAZIL</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>Odilon Vanni de</given_name><surname>Queiroz</surname><affiliation>Universidade Federal de Minas Gerais,  BRAZIL</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>Isabel Cristina</given_name><surname>Gomes</surname><affiliation>Universidade Federal de Minas Gerais,  BRAZIL</affiliation></person_name></contributors></journal_article></journal></body></doi_batch>', ET.tostring(xml))
 
     def test_article_publication_date_element(self):
 
@@ -458,7 +465,7 @@ class ExportCrossRef_one_DOI_only_Tests(unittest.TestCase):
 
     def test_validating_against_schema(self):
 
-        xml = export.Export(self._raw_json).pipeline_crossref()
+        xml = export.Export(self._raw_json).pipeline_crossref(Mock())
 
         xmlio = ET.parse(io.BytesIO(xml))
 


### PR DESCRIPTION
#### O que esse PR faz?
Para enviar ao CrossRef tag `<suffix>` em XMLs exportados, é
necessário verificar se há sufixo presente nos campos `surname` em
`xylose.scielodocument.Article.authors`, pois não há um campo separado na base ISIS para este dado.
Como o número de sufixos possíveis é muito grande, foi decido mantê-los no MongoDB. Assim, será possível incluir todos os sufixos possíveis e, caso seja encontrado um novo, basta adicioná-lo.
Neste momento, somente o CrossRef está retornando erro por conta desta tag. Por isso, foi decido fazer o tratamento dela pontualmente neste exportador.
O tratamento é feito somente se o sufixo for encontrado no controle de sufixos. Caso contrário, a tag `<surname>` continua sendo enviado da mesma forma.

Resumindo:
- Adiciona capacidade de criar novo sufixo no MongoDB
- Adiciona checagem da existência de sufixo no MongoDB
- Altera pipeline do exportador do CrossRef para adicionar tag `<suffix>` em Contribuidores no XML caso detectado sufixo cadastrado no MongoDB

#### Onde a revisão poderia começar?
Em `articlemeta/export.py` e `articlemeta/export_crossref.py`

#### Como este poderia ser testado manualmente?
- É preciso um artigo com contribuidores sendo que, ao menos, um deles tenha o sufixo no campo de sobrenome. Ex: http://articlemeta.scielo.org/api/v1/article/?code=S0034-89102010000400007&collection=scl, sufixo *Junior*
- Adicionar sufixo *junior* na coleção `name_suffixes` no MongoDB do AM
- Acessar Ex: http://articlemeta.scielo.org/api/v1/article/?code=S0034-89102010000400007&collection=scl&format=xmlcrossref
- Verificar se foi adicionada a tag `<suffix>` contendo *Junior*
- Os outros sobrenomes devem permanecer da mesma forma.

#### Algum cenário de contexto que queira dar?
Detalhes no ticket #166 

### Screenshots
N/A.

#### Quais são tickets relevantes?
#166

### Referências
Nenhuma.
