### PR TITLE
Adiciona licença de uso ao exportar para o CrossRef

### DIFF
--- a/articlemeta/export.py
+++ b/articlemeta/export.py
@@ -206,6 +206,7 @@ class Export(object):
             export_crossref.XMLArticlePubDatePipe(),
             export_crossref.XMLPagesPipe(),
             export_crossref.XMLPIDPipe(),
+            export_crossref.XMLPermissionsPipe(),
             export_crossref.XMLDOIDataPipe(),
             export_crossref.XMLDOIPipe(),
             export_crossref.XMLResourcePipe(),

--- a/tests/test_export_crossref.py
+++ b/tests/test_export_crossref.py
@@ -473,6 +473,60 @@ class ExportCrossRef_one_DOI_only_Tests(unittest.TestCase):
         self.assertEqual(None, schema.assertValid(xmlio))
 
 
+    def test_every_journal_article_must_contain_own_license(self):
+            self._article_meta.data["license"] = "by/4.0"
+
+            xmlcrossref = create_xmlcrossref_with_n_journal_article_element(
+                ["pt", "en", "es"]
+            )
+
+            data = [self._article_meta, xmlcrossref]
+            xmlcrossref = export_crossref.XMLPermissionsPipe()
+            _, xml = xmlcrossref.transform(data)
+
+            programs = xml.findall(
+                ".//{http://www.crossref.org/AccessIndicators.xsd}program"
+            )
+            self.assertEqual(3, len(programs))
+
+            for journal_article in xml.findall(".//journal_article"):
+                with self.subTest(journal_article=journal_article):
+                    program = journal_article.findall(
+                        ".//{http://www.crossref.org/AccessIndicators.xsd}program"
+                    )
+                    self.assertIsNotNone(program)
+                    self.assertEqual(1, len(program))
+                    self.assertEqual(
+                        3,
+                        len(
+                            program[0].findall(
+                                "{http://www.crossref.org/AccessIndicators.xsd}license_ref"
+                            )
+                        ),
+                    )
+                    self.assertIsNotNone(
+                        program[0].findall(
+                            "{http://www.crossref.org/AccessIndicators.xsd}free_to_read"
+                        )
+                    )
+
+
+    def test_journal_article_should_not_contain_licenses(self):
+            xmlcrossref = create_xmlcrossref_with_n_journal_article_element(
+                ["pt", "en", "es"]
+            )
+
+            data = [self._article_meta, xmlcrossref]
+            xmlcrossref = export_crossref.XMLPermissionsPipe()
+            _, xml = xmlcrossref.transform(data)
+
+            programs = xml.findall(
+                ".//{http://www.crossref.org/AccessIndicators.xsd}program"
+            )
+
+            self.assertIsNotNone(programs)
+
+
 class ExportCrossRef_MultiLingueDoc_with_MultipleDOI_Tests(unittest.TestCase):
 
     def setUp(self):
@@ -974,6 +1028,60 @@ class ExportCrossRef_MultiLingueDoc_with_MultipleDOI_Tests(unittest.TestCase):
         raw, xml = xmlcrossref.transform(data)
         self.assertEqual(
             3, len(xml.findall('.//journal_article//citation_list')))
+
+
+    def test_every_journal_article_must_contain_own_license(self):
+            self._article.data["license"] = "by/4.0"
+
+            xmlcrossref = create_xmlcrossref_with_n_journal_article_element(
+                ["pt", "en", "es"]
+            )
+
+            data = [self._article, xmlcrossref]
+            xmlcrossref = export_crossref.XMLPermissionsPipe()
+            _, xml = xmlcrossref.transform(data)
+
+            programs = xml.findall(
+                ".//{http://www.crossref.org/AccessIndicators.xsd}program"
+            )
+            self.assertEqual(3, len(programs))
+
+            for journal_article in xml.findall(".//journal_article"):
+                with self.subTest(journal_article=journal_article):
+                    program = journal_article.findall(
+                        ".//{http://www.crossref.org/AccessIndicators.xsd}program"
+                    )
+                    self.assertIsNotNone(program)
+                    self.assertEqual(1, len(program))
+                    self.assertEqual(
+                        3,
+                        len(
+                            program[0].findall(
+                                "{http://www.crossref.org/AccessIndicators.xsd}license_ref"
+                            )
+                        ),
+                    )
+                    self.assertIsNotNone(
+                        program[0].findall(
+                            "{http://www.crossref.org/AccessIndicators.xsd}free_to_read"
+                        )
+                    )
+
+
+    def test_journal_article_should_not_contain_licenses(self):
+            xmlcrossref = create_xmlcrossref_with_n_journal_article_element(
+                ["pt", "en", "es"]
+            )
+
+            data = [self._article, xmlcrossref]
+            xmlcrossref = export_crossref.XMLPermissionsPipe()
+            _, xml = xmlcrossref.transform(data)
+
+            programs = xml.findall(
+                ".//{http://www.crossref.org/AccessIndicators.xsd}program"
+            )
+
+            self.assertIsNotNone(programs)
 
 
 class ExportCrossRef_MultiLingueDoc_with_DOI_pt_es_Tests(unittest.TestCase):


### PR DESCRIPTION
#### O que esse PR faz?
Este pull request adiciona a possibilidade de exportar o XML-CrossRef com as licenças de uso pertinentes ao artigo exportado (se houver).

#### Onde a revisão poderia começar?
- `articlemeta/export_crossref.py` L: `561`

#### Como este poderia ser testado manualmente?
Para testar manualmente este PR deve-se:
- Iniciar o ArticleMeta;
- Fazer uma requisição para um artigo que possua licença de uso;
- Observar a adição da licença referida pelo artigo;
- Fazer uma requisição para um artigo que não possua licença de uso;
- Observar a não adição de licença para o artigo;

#### Algum cenário de contexto que queira dar?
N/A

### Screenshots
N/A

#### Quais são tickets relevantes?
#165 

### Referências

[Access Indicator XSD](https://data.crossref.org/reports/help/schema_doc/doi_resources4.3.6/AccessIndicators_xsd.html)
[CrossRef Schema DOC](http://data.crossref.org/reports/help/schema_doc/4.4.0/fundref_xsd.html#program)
[CrossRef XSL](https://github.com/CrossRef/jats-crossref-xslt/blob/12eb020e4d9b0948df8938807b2132f811a3f58d/JATS2CrossRef_web.xsl#L538)
[eLife Feed Example](https://github.com/elifesciences/elife-crossref-feed/blob/master/2050-084X_2013_elife00178.xml#L152-L156)
