### PR TITLE
Altera a versão do xylose para 1.35.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ thriftpy==0.3.9
 urllib3==1.22
 venusian==1.1.0
 WebOb==1.8.0rc1
--e git+https://github.com/scieloorg/xylose.git@1.35.4#egg=xylose
+-e git+https://github.com/scieloorg/xylose.git@1.35.5#egg=xylose
 zope.deprecation==4.3.0
 zope.interface==4.4.3
 crossrefapi==1.3.0

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ requires = [
     'pyramid>=1.5.4',
     'thriftpy>=0.3.1',
     'thriftpywrap',
-    'xylose>=1.35.4',
+    'xylose>=1.35.5',
     'crossrefapi>=1.3',
     ]
 
@@ -25,7 +25,7 @@ test_requires = ['mocker', 'nose>=1.0', 'coverage', 'mongomock']
 
 setup(
     name="articlemeta",
-    version='1.45.0',
+    version='1.45.1',
     description="A SciELO API to load SciELO Articles metadata",
     author="SciELO",
     author_email="scielo-dev@googlegroups.com",
@@ -44,7 +44,7 @@ setup(
     ],
     dependency_links=[
         "git+https://github.com/scieloorg/thriftpy-wrap@0.1.1#egg=thriftpywrap",
-        "git+https://github.com/scieloorg/xylose.git@1.35.4#egg=xylose",
+        "git+https://github.com/scieloorg/xylose.git@1.35.5#egg=xylose",
     ],
     include_package_data=True,
     zip_safe=False,


### PR DESCRIPTION
#### O que esse PR faz?
Atualizar a versão do xylose para 1.35.5, que corrige os valores dos subcampos de idioma e DOI no campo v337.

#### Onde a revisão poderia começar?
n/a

#### Como este poderia ser testado manualmente?
n/a

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
https://github.com/scieloorg/xylose/issues/177

### Referências
n/a
