### PR TITLE
Incluir os IDs das versões scielo-v2 e scielo-v3 ao consultar o forma…

### DIFF
--- a/articlemeta/export_rsps.py
+++ b/articlemeta/export_rsps.py
@@ -639,12 +639,20 @@ class XMLArticleMetaArticleIdPublisherPipe(plumber.Pipe):
         except UnavailableMetadataException as e:
             pass
 
-        articleidpublisher = ET.Element('article-id')
-        articleidpublisher.set('pub-id-type', 'publisher-id')
-        articleidpublisher.text = raw.publisher_id
+        article_id_items = []
+        if raw.publisher_id:
+            article_id_items.append(
+                ("scielo-v2", raw.publisher_id))
+        if raw.data['article'].get("v885"):
+            article_id_items.append(
+                ("scielo-v3", raw.data['article']['v885'][0]['_']))
 
-        article_meta.append(articleidpublisher)
-
+        for version, value in article_id_items:
+            articleidpublisher = ET.Element('article-id')
+            articleidpublisher.set('pub-id-type', 'publisher-id')
+            articleidpublisher.set('specific-use', version)
+            articleidpublisher.text = value
+            article_meta.append(articleidpublisher)
         return data
 
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import os
 from setuptools import setup, find_packages
 
 here = os.path.abspath(os.path.dirname(__file__))
-with open(os.path.join(here, 'README.rst')) as f:
+with open(os.path.join(here, 'README.md')) as f:
     README = f.read()
 with open(os.path.join(here, 'CHANGES.txt')) as f:
     CHANGES = f.read()

--- a/tests/test_export_rsps.py
+++ b/tests/test_export_rsps.py
@@ -572,7 +572,48 @@ class ExportTests(unittest.TestCase):
 
         articleidpublisher = xml.find('./front/article-meta/article-id[@pub-id-type="publisher-id"]').text
 
-        self.assertEqual(u'S0034-89102010000400007', articleidpublisher)
+    def test_xml_article_meta_article_id_publisher_pipe_creates_scielo_v2_v3(self):
+        fakexylosearticle = Article(
+                                {'article': {
+                                    "v880": [{"_": "SXXXXX2"}],
+                                    "v885": [{"_": "SXXXXX3"}],
+                                    "v2": [{"_": "SXXXXX1"}],
+                                }},
+                            )
+
+        pxml = ET.Element('article')
+        pxml.append(ET.Element('front'))
+
+        front = pxml.find('front')
+        front.append(ET.Element('article-meta'))
+
+        data = [fakexylosearticle, pxml]
+        xmlarticle = export_rsps.XMLArticleMetaArticleIdPublisherPipe()
+        raw, xml = xmlarticle.transform(data)
+        article_id = xml.findall('./front/article-meta/article-id[@pub-id-type="publisher-id"]')
+        self.assertEqual(article_id[0].text, "SXXXXX2")
+        self.assertEqual(article_id[1].text, "SXXXXX3")
+
+    def test_xml_article_meta_article_id_publisher_pipe_creates_scielo_v2(self):
+        fakexylosearticle = Article(
+                                {'article': {
+                                    "v880": [{"_": "SXXXXX2"}],
+                                    "v2": [{"_": "SXXXXX1"}],
+                                }},
+                            )
+
+        pxml = ET.Element('article')
+        pxml.append(ET.Element('front'))
+
+        front = pxml.find('front')
+        front.append(ET.Element('article-meta'))
+
+        data = [fakexylosearticle, pxml]
+        xmlarticle = export_rsps.XMLArticleMetaArticleIdPublisherPipe()
+        raw, xml = xmlarticle.transform(data)
+        article_id = xml.findall('./front/article-meta/article-id[@pub-id-type="publisher-id"]')
+        self.assertEqual(article_id[0].text, "SXXXXX2")
+        self.assertEqual(len(article_id), 1)
 
     def test_xml_article_meta_article_id_doi_pipe(self):
 


### PR DESCRIPTION
…to xmlrsps

#### O que esse PR faz?
Incluir os IDs correspondentes aos formatos scielo-v2 e scielo-v3

#### Onde a revisão poderia começar?
`articlemeta/export_rsps.py: 642`

#### Como este poderia ser testado manualmente?
Com os comandos:
`export ARTICLEMETA_SETTINGS_FILE=development.ini-TEMPLATE`
`python setup.py test -s tests.test_export_rsps.ExportTests`

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
#190, https://github.com/scieloorg/PC-Programs/issues/3145

### Referências
https://github.com/scieloorg/kernel/blob/master/docs/adr/0006-novo-pid-do-scielo.md