### PR TITLE
Adiciona o PID scielo-v1 no XML SPS

### DIFF
--- a/articlemeta/export_rsps.py
+++ b/articlemeta/export_rsps.py
@@ -643,6 +643,9 @@ class XMLArticleMetaArticleIdPublisherPipe(plumber.Pipe):
         if raw.publisher_id:
             article_id_items.append(
                 ("scielo-v2", raw.publisher_id))
+        if raw.data['article'].get("v2"):
+            article_id_items.append(
+                ("scielo-v1", raw.data['article']['v2'][0]['_']))
         if raw.data['article'].get("v885"):
             article_id_items.append(
                 ("scielo-v3", raw.data['article']['v885'][0]['_']))

--- a/tests/test_export_rsps.py
+++ b/tests/test_export_rsps.py
@@ -592,7 +592,8 @@ class ExportTests(unittest.TestCase):
         raw, xml = xmlarticle.transform(data)
         article_id = xml.findall('./front/article-meta/article-id[@pub-id-type="publisher-id"]')
         self.assertEqual(article_id[0].text, "SXXXXX2")
-        self.assertEqual(article_id[1].text, "SXXXXX3")
+        self.assertEqual(article_id[1].text, "SXXXXX1")
+        self.assertEqual(article_id[2].text, "SXXXXX3")
 
     def test_xml_article_meta_article_id_publisher_pipe_creates_scielo_v2(self):
         fakexylosearticle = Article(
@@ -613,7 +614,8 @@ class ExportTests(unittest.TestCase):
         raw, xml = xmlarticle.transform(data)
         article_id = xml.findall('./front/article-meta/article-id[@pub-id-type="publisher-id"]')
         self.assertEqual(article_id[0].text, "SXXXXX2")
-        self.assertEqual(len(article_id), 1)
+        self.assertEqual(article_id[1].text, "SXXXXX1")
+        self.assertEqual(len(article_id), 2)
 
     def test_xml_article_meta_article_id_doi_pipe(self):
 


### PR DESCRIPTION
#### O que esse PR faz?
Adiciona o PID SciELO V1 no XML formato SPS, primeira versão do SciELO PID, presente nos primeiros artigos publicados.

#### Onde a revisão poderia começar?
Em `articlemeta/export_rsps.py`, no pipe que trata dos *Publisher IDs*

#### Como este poderia ser testado manualmente?
- Acesse um artigo informando no path o atributo `format=xmlrsps` para retornar o XML sintetizado
- Verifique se está presente o campo [v2] do artigo na tag, como no exemplo:

```xml
<article-id pub-id-type="publisher-id" specific-use="scielo-v1">S2176-4573(12)00700101</article-id>
```

#### Algum cenário de contexto que queira dar?
N/A

### Screenshots
N/A

#### Quais são tickets relevantes?
#193, scieloorg/document-store-migracao/issues/215

### Referências
ADR sobre novo PID: https://github.com/scieloorg/kernel/blob/master/docs/adr/0006-novo-pid-do-scielo.md
