### PR TITLE
Ignora a transformação de links inválidos no elemento mixed-citation

### DIFF
--- a/articlemeta/utils.py
+++ b/articlemeta/utils.py
@@ -13,6 +13,10 @@ def convert_ahref_to_extlink(xml_etree):
 
     for ahref in xml_etree.findall('.//a'):
         uri = ahref.get('href', '')
+
+        if len(uri) == 0 or not uri.strip().startswith("http"):
+            continue
+
         ahref.tag = 'ext-link'
         ahref.set('ext-link-type', 'uri')
         ahref.set('{http://www.w3.org/1999/xlink}href', uri)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,23 @@
+import unittest
+from lxml import etree
+from articlemeta.utils import convert_ahref_to_extlink
+
+
+class TestConvertAtoExtlink(unittest.TestCase):
+    def setUp(self):
+        self.etree_with_links = etree.fromstring(
+            """<xml>
+                <a href="">text</a>
+                <a href="#local">text</a>
+                <a href="https://www.scielo.br">text</a>
+            </xml>"""
+        )
+
+    def test_should_not_convert_a_to_extlink_when_href_is_empty_or_local(self):
+        xml_etree = convert_ahref_to_extlink(self.etree_with_links)
+        self.assertEqual(2, len(xml_etree.findall(".//a")))
+
+    def test_should_convert_a_to_extlink_when_href_have_http_string(self):
+        xml_etree = convert_ahref_to_extlink(self.etree_with_links)
+        self.assertEqual(1, len(xml_etree.findall(".//ext-link")))
+


### PR DESCRIPTION
#### O que esse PR faz?

Este pull request corrige um comportamento não esperado durante a transformação das tags `<a>` dentro do elemento `mixed-citation` do `artigo` no formato `xmlrsps`. 

#### Onde a revisão poderia começar?
- `articlemeta/utils.py` L: `17`

#### Como este poderia ser testado manualmente?
Para testar este pr manualmente deve-se:
- Iniciar uma instância do article meta:
- Acessar o artigo via url `/api/v1/article/?collection=scl&code=S0021-75572002000300005&format=xmlrsps`;
- Verificar que as tags `a` sem `href` não foram transformadas em `ext-link`.

#### Algum cenário de contexto que queira dar?
N/A

### Screenshots
![Screen Shot 2019-12-10 at 18 03 35](https://user-images.githubusercontent.com/4604104/70568815-68b56d00-1b77-11ea-83e8-72b6d05b01ac.png)

#### Quais são tickets relevantes?
#188 

### Referências
N/A
