### PR TITLE
Adiciona fallback para `issue` e `volume` durante pipeline do xmlrsps

### DIFF
--- a/articlemeta/export_rsps.py
+++ b/articlemeta/export_rsps.py
@@ -999,9 +999,12 @@ class XMLArticleMetaIssueInfoPipe(plumber.Pipe):
 
         for name, default in fields:
             try:
-                labels[name] = getattr(raw.issue, name, default) or default
-            except UnavailableMetadataException:
+                labels[name] = getattr(raw.issue, name)
+            except (UnavailableMetadataException, AttributeError):
                 labels[name] = default
+            else:
+                if labels[name] is None:
+                    labels[name] = default
 
         for supplement in ["supplement_number", "supplement_volume"]:
             if labels[supplement] is not None and len(labels[supplement]) > 0:

--- a/articlemeta/export_rsps.py
+++ b/articlemeta/export_rsps.py
@@ -971,21 +971,6 @@ class XMLArticleMetaElocationInfoPipe(plumber.Pipe):
 
 class XMLArticleMetaIssueInfoPipe(plumber.Pipe):
 
-    def precond(data):
-
-        raw, xml = data
-
-        try:
-            if not raw.issue:
-                raise plumber.UnmetPrecondition()
-        except UnavailableMetadataException as e:
-            volume = raw.data.get("article", {}).get("v31", [{}])[0].get("_", None)
-            number = raw.data.get("article", {}).get("v32", [{}])[0].get("_", None)
-
-            if volume is None and number is None:
-                raise plumber.UnmetPrecondition()
-
-    @plumber.precondition(precond)
     def transform(self, data):
         raw, xml = data
         labels = {}

--- a/articlemeta/export_rsps.py
+++ b/articlemeta/export_rsps.py
@@ -15,6 +15,7 @@ LANG_REGEX = re.compile(r'ns\d:lang')
 URI_REGEXT = re.compile(r'http://.*')
 SUPPLBEG_REGEX = re.compile(r'^0 ')
 SUPPLEND_REGEX = re.compile(r' 0$')
+REMOVE_AHEAD_STR_REGEX = re.compile(r"ahead")
 
 
 class XMLCitation(object):
@@ -1006,7 +1007,7 @@ class XMLArticleMetaIssueInfoPipe(plumber.Pipe):
             if labels[supplement] is not None and len(labels[supplement]) > 0:
                 labels["number"] += " suppl %s" % labels[supplement]
 
-        for regex in [SUPPLBEG_REGEX, SUPPLEND_REGEX, re.compile(r"ahead")]:
+        for regex in [SUPPLBEG_REGEX, SUPPLEND_REGEX, REMOVE_AHEAD_STR_REGEX]:
             labels["number"] = regex.sub("", labels["number"])
 
         articlemeta = xml.find('./front/article-meta')

--- a/tests/test_export_rsps.py
+++ b/tests/test_export_rsps.py
@@ -1149,6 +1149,7 @@ class ExportTests(unittest.TestCase):
     def test_xmlarticle_meta_general_info_without_volume_pipe(self):
 
         del(self._article_meta.data['issue']['issue']['v31'])
+        del(self._article_meta.data['article']['v31'])
 
         pxml = ET.Element('article')
         pxml.append(ET.Element('front'))
@@ -1183,6 +1184,7 @@ class ExportTests(unittest.TestCase):
     def test_xmlarticle_meta_general_info_without_issue_pipe(self):
 
         del(self._article_meta.data['issue']['issue']['v32'])
+        del(self._article_meta.data['article']['v32'])
 
         pxml = ET.Element('article')
         pxml.append(ET.Element('front'))
@@ -1201,6 +1203,7 @@ class ExportTests(unittest.TestCase):
 
         self._article_meta.data['issue']['issue']['v65'] = [{'_': '201008'}]
         del(self._article_meta.data['issue']['issue']['v32'])
+        del(self._article_meta.data['article']['v32'])
         self._article_meta.data['issue']['issue']['v131'] = [{'_': '1'}]
 
         pxml = ET.Element('article')
@@ -1222,6 +1225,7 @@ class ExportTests(unittest.TestCase):
 
         self._article_meta.data['issue']['issue']['v65'] = [{'_': '201008'}]
         del(self._article_meta.data['issue']['issue']['v32'])
+        del(self._article_meta.data['article']['v32'])
         self._article_meta.data['issue']['issue']['v31'] = [{'_': '10'}]
         self._article_meta.data['issue']['issue']['v131'] = [{'_': '0'}]
 
@@ -1583,6 +1587,44 @@ class ExportTests(unittest.TestCase):
         citations = len(xml.findall('./back/ref-list/ref'))
 
         self.assertEqual(23, citations)
+
+    def test_xml_article_meta_issue_info_pipeline_should_look_by_volume_in_article_if_property_is_not_present_in_issue(self):
+
+        del(self._article_meta.data['issue']['issue']['v31']) # remove volume from issue object
+        self._article_meta.data['article']['v31'] = [{"_": "100"}]
+
+        pxml = ET.Element('article')
+        pxml.append(ET.Element('front'))
+
+        front = pxml.find('front')
+        front.append(ET.Element('article-meta'))
+
+        data = [self._article_meta, pxml]
+
+        xmlarticle = export_rsps.XMLArticleMetaIssueInfoPipe()
+        raw, xml = xmlarticle.transform(data)
+
+        self.assertIsNotNone(xml.find('./front/article-meta/volume'))
+        self.assertEqual("100", xml.find('./front/article-meta/volume').text)
+
+    def test_xml_article_meta_issue_info_pipeline_should_look_by_number_in_article_if_property_is_not_present_in_issue(self):
+
+        del(self._article_meta.data['issue']['issue']['v32']) # remove number from issue object
+        self._article_meta.data['article']['v32'] = [{"_": "100"}]
+
+        pxml = ET.Element('article')
+        pxml.append(ET.Element('front'))
+
+        front = pxml.find('front')
+        front.append(ET.Element('article-meta'))
+
+        data = [self._article_meta, pxml]
+
+        xmlarticle = export_rsps.XMLArticleMetaIssueInfoPipe()
+        raw, xml = xmlarticle.transform(data)
+
+        self.assertIsNotNone(xml.find('./front/article-meta/issue'))
+        self.assertEqual("100", xml.find('./front/article-meta/issue').text)
 
 
 class ExportRSPS_XMLArticleMetaIssueInfoPipe_Tests(unittest.TestCase):


### PR DESCRIPTION
#### O que esse PR faz?

Este pull request corrige a produção de XML para o formato `xmlrsps` onde o `<volume>` e `<issue>` são capturados a partir da propriedade `.issue` ou do próprio `artigo`.

#### Onde a revisão poderia começar?
- `articlemeta/export_rsps.py` L: `980`

#### Como este poderia ser testado manualmente?
Para testar este pull request manualmente, deve-se:
- Rode uma instância do Article Meta;
- Acesse um artigo objeto do problema (ex `api/v1/article/?collection=cub&code=S0253-570X2018000100010&format=xmlrsps`);
- Observe que as tags `volume` e `issue` foram preenchidas;
- Acesse um `artigo` publicado em um`suplemento` (ex `/api/v1/article/?collection=scl&format=xmlrsps&code=S0034-89102018000200506`)
- Observe que o suplemento foi preenchido adequadamente;
- Acesse um documento do tipo `ahead`;
- Observe que as tags de `volume` e `issue` não foram preenchidos;

#### Algum cenário de contexto que queira dar?

Optei por manter a consulta da propriedade `issue` por não conhecer todas as situações envolvendo o relacionamento das informações entre `artigo` e `issue`. Sendo assim preservamos os comportamentos já conhecidos e ganhamos a capacidade de buscar o dado em uma outra fonte.

### Screenshots
N/A

#### Quais são tickets relevantes?
#195 

### Referências
N/A
