### PR TITLE
Corrige TypeError na execução dos utilitários *articlemeta_loadlicense* e *articlemeta_loaddoi*

### DIFF
--- a/processing/load_doi.py
+++ b/processing/load_doi.py
@@ -220,7 +220,7 @@ def main():
     parser.add_argument(
         '--collection',
         '-c',
-        choices=collections_acronym(),
+        choices=_collections,
         help='Collection acronym'
     )
 

--- a/processing/load_licenses.py
+++ b/processing/load_licenses.py
@@ -203,7 +203,7 @@ def main():
     parser.add_argument(
         '--collection',
         '-c',
-        choices=collections_acronym(),
+        choices=_collections_acronyms,
         help='Collection acronym'
     )
 


### PR DESCRIPTION
#### O que esse PR faz?

Resolve exceção do tipo `TypeError` que causa a interrupção da execução dos utilitários `articlemeta_loadlicense` e `articlemeta_loaddoi`.

#### Onde a revisão poderia começar?

A modificação é extremamente pequena, portanto não há como dar uma dica aqui.

#### Como este poderia ser testado manualmente?

Execute os comandos `articlemeta_loadlicense -h` e `articlemeta_loaddoi -h` e observe que não é levantada nenhuma exceção.

obs: a execução dos comandos necessita de uma instância de MongoDB, mesmo que nenhuma ação seja de fato executada.

#### Algum cenário de contexto que queira dar?

n/a

### Screenshots

n/a

#### Quais são tickets relevantes?

#198 

### Referências

n/a
