### PR TITLE
Corrige campo email da afiliação na exportação do XML SPS

### DIFF
--- a/articlemeta/export_rsps.py
+++ b/articlemeta/export_rsps.py
@@ -884,7 +884,7 @@ class XMLArticleMetaAffiliationPipe(plumber.Pipe):
 
             if 'email' in affiliation:
                 email = ET.Element('email')
-                email.text = affiliation['email']
+                email.text = affiliation.get('email_html_removed', affiliation['email'])
                 aff.append(email)
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ thriftpy==0.3.9
 urllib3==1.22
 venusian==1.1.0
 WebOb==1.8.0rc1
--e git+https://github.com/scieloorg/xylose.git@1.35.6#egg=xylose
+-e git+https://github.com/scieloorg/xylose.git@1.35.7#egg=xylose
 zope.deprecation==4.3.0
 zope.interface==4.4.3
 crossrefapi==1.3.0

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ requires = [
     'pyramid>=1.5.4',
     'thriftpy>=0.3.1',
     'thriftpywrap',
-    'xylose>=1.35.6',
+    'xylose>=1.35.7',
     'crossrefapi>=1.3',
     ]
 

--- a/tests/test_export_rsps.py
+++ b/tests/test_export_rsps.py
@@ -987,6 +987,41 @@ class ExportTests(unittest.TestCase):
                           u'São Paulo',
                           u'Belo Horizonte']), address)
 
+    def test_xmlarticle_meta_affiliation_email_pipe(self):
+        pxml = ET.Element('article')
+        pxml.append(ET.Element('front'))
+        front = pxml.find('front')
+        front.append(ET.Element('article-meta'))
+        self._article_meta.data['article']['v70'] = [
+            {
+                u"c": u"Sorocaba",
+                u"e": u'<A HREF="mailto:abcd@inst.br">abcd@inst.br</A>',
+                u"i": u"A01",
+                u"1": u"Departamento de Ci\u00eancias Ambientais 1",
+                u"2": u"Departamento de Ci\u00eancias Ambientais 2",
+                u"p": u"BRAZIL",
+                u"s": u"SP",
+                u"z": u"18052-780"
+            },
+            {
+                u"c": u"Sorocaba",
+                u"e": u'efgh@inst.br',
+                u"i": u"A02",
+                u"1": u"Departamento de Ci\u00eancias Ambientais 1",
+                u"2": u"Departamento de Ci\u00eancias Ambientais 2",
+                u"p": u"BRAZIL",
+                u"s": u"SP",
+                u"z": u"18052-780"
+            },
+        ]
+        data = [self._article_meta, pxml]
+
+        xmlarticle = export_rsps.XMLArticleMetaAffiliationPipe()
+        raw, xml = xmlarticle.transform(data)
+
+        emails = sorted([i.text for i in xml.findall('./front/article-meta/aff/email')])
+        self.assertEqual(emails, [u"abcd@inst.br", u"efgh@inst.br"])
+
     def test_xmlarticle_meta_general_info_pub_year_pipe(self):
 
         pxml = ET.Element('article')


### PR DESCRIPTION
#### O que esse PR faz?
Este PR corrige a exportação de XMLs SPS, especificamente no campo `email` das afiliações.

#### Onde a revisão poderia começar?
Em `tests/test_export_rsps.py`, que possui teste que exemplifica como o dado está na base ISIS.

#### Como este poderia ser testado manualmente?
Executando `python setup.py test -s tests.tex_export_rsps`

OU

Acesse algum artigo via API REST com `format=xmlrsps` que tenha campo email na afiliação, com e sem a tag HTML `<a>`. Nos dois casos, o email deve retornar somente com o texto da tag. Exemplo de artigo com tag HTML no campo: `http://articlemeta.scielo.org/api/v1/article/?collection=scl&code=S0102-311X2007000100001&format=xmlrsps`.

#### Algum cenário de contexto que queira dar?
Alguns artigos HTML tiveram o campo de email da afiliação marcado com a tag `<a>`. Esta alteração utiliza campo tratado no Xylose para resolver o problema na exportação do XML SPS caso exista.

### Screenshots
![Screen Shot 2019-12-19 at 16 13 03](https://user-images.githubusercontent.com/18053487/71202579-4a3c2980-227b-11ea-9bb9-596db9a16251.png)

#### Quais são tickets relevantes?
#185

### Referências
Nenhuma.
