### PR TITLE
Corrige argumentos passados para função collection_info

### DIFF
--- a/processing/load_licenses.py
+++ b/processing/load_licenses.py
@@ -152,7 +152,7 @@ def run(articlemeta_db, collections, all_records=False):
         exit()
 
     for collection in collections:
-        coll_info = collection_info(collection)
+        coll_info = collection_info(articlemeta_db, collection)
 
         logger.info(u'Loading licenses for %s', coll_info['domain'])
         logger.info(u'Using mode all_records %s', str(all_records))


### PR DESCRIPTION
#### O que esse PR faz?
Corrige execução incorreta da função `processing.load_licenses.collection_info`.

#### Onde a revisão poderia começar?
A mudança é mínima, vá ao visualizador de códigos do próprio GitHub.

#### Como este poderia ser testado manualmente?
Será necessário executar o comando em uma instância local, por exemplo `articlemeta_loadlicenses -c cub`.

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
#203 

### Referências
n/a
