### PR TITLE
Adiciona tag self-uri para a exportação de XML no formato rsps

### DIFF
--- a/articlemeta/export.py
+++ b/articlemeta/export.py
@@ -109,6 +109,7 @@ class Export(object):
                                export_rsps.XMLArticleMetaPagesInfoPipe(),
                                export_rsps.XMLArticleMetaHistoryPipe(),
                                export_rsps.XMLArticleMetaPermissionPipe(),
+                               export_rsps.XMLArticleMetaSelfUriPipe(),
                                export_rsps.XMLArticleMetaAbstractsPipe(),
                                export_rsps.XMLArticleMetaKeywordsPipe(),
                                export_rsps.XMLArticleMetaCountsPipe(),

--- a/tests/test_export_rsps.py
+++ b/tests/test_export_rsps.py
@@ -1587,6 +1587,45 @@ class ExportTests(unittest.TestCase):
 
         self.assertEqual(None, citations)
 
+    def test_xml_article_meta_should_contains_self_uris_when_pdf_are_linked_to_article(self):
+        article_xml = ET.Element("article")
+        front = ET.Element("front")
+        front.append(ET.Element("article-meta"))
+        article_xml.append(front)
+
+        data = [self._article_meta, article_xml]
+        xmlarticle = export_rsps.XMLArticleMetaSelfUriPipe()
+        raw, xml = xmlarticle.transform(data)
+
+        self.assertEqual(2, len(xml.findall(".//self-uri")))
+
+    def test_self_uri_tags_should_contain_language_attribute_referencing_pdf_lang(self):
+        article_xml = ET.Element("article")
+        front = ET.Element("front")
+        front.append(ET.Element("article-meta"))
+        article_xml.append(front)
+
+        data = [self._article_meta, article_xml]
+        xmlarticle = export_rsps.XMLArticleMetaSelfUriPipe()
+        raw, xml = xmlarticle.transform(data)
+
+        for tag in xml.findall(".//self-uri"):
+            self.assertTrue(tag.get("{http://www.w3.org/XML/1998/namespace}lang"))
+
+    def test_self_uri_tags_should_output_english_text_as_default(self):
+        article_xml = ET.Element("article")
+        front = ET.Element("front")
+        front.append(ET.Element("article-meta"))
+        article_xml.append(front)
+
+        self._article_meta.data["fulltexts"]["pdf"].update({"fr": "http://fake-url/fr.pdf"})
+
+        data = [self._article_meta, article_xml]
+        xmlarticle = export_rsps.XMLArticleMetaSelfUriPipe()
+        raw, xml = xmlarticle.transform(data)
+        self_uri_fr = xml.find(".//self-uri[@{http://www.w3.org/XML/1998/namespace}lang='fr']")
+        self.assertEqual("Full text available only in PDF format (FR)", self_uri_fr.text)
+
     def test_xml_citations_without_data_pipe(self):
 
         fakexylosearticle = Article({'article': {}, 'title': {}, 'citatons': {}})


### PR DESCRIPTION
#### O que esse PR faz?
Este pull request adiciona ao formato `rsps` a tag `self-uri` quando o artigo exportado tiver `pdfs` associados ao seu registro.

#### Onde a revisão poderia começar?
- `articlemeta/export_rsps.py`: L: `1165`

#### Como este poderia ser testado manualmente?
Para testar este PR manualmente, deve-se:
- Executar uma instância do article meta;
- Acessar um artigo (ex `S0074-02761922000100006`) utilizando o formato `xmlrsps`;
- Observar a tag `self-uri` referenciando o(s) pdf(s) do artigo;
- Acessar um artigo que não possui `pdf`;
- Observar que a tag `self-uri` não é renderizada.

#### Algum cenário de contexto que queira dar?
N/A

### Screenshots
<img width="711" alt="Screen Shot 2020-01-24 at 09 04 31" src="https://user-images.githubusercontent.com/4604104/73067888-971dac00-3e88-11ea-8c30-60b06fb04ebd.png">

#### Quais são tickets relevantes?
https://github.com/scieloorg/document-store-migracao/issues/206

### Referências
N/A
