### PR TITLE
Corrige URL inválida no XML do SciELO CI

### DIFF
--- a/articlemeta/export_sci.py
+++ b/articlemeta/export_sci.py
@@ -1,5 +1,6 @@
 # coding: utf-8
 import re
+from urllib.parse import quote, urlsplit, urlunsplit
 
 from lxml import etree as ET
 
@@ -1043,7 +1044,13 @@ class XMLArticleMetaCitationsPipe(plumber.Pipe):
 
         cit = XMLCitation()
         for citation in raw.citations:
-            reflist.append(cit.deploy(citation)[1])
+            ref = cit.deploy(citation)[1]
+            extlinks = ref.xpath("element-citation/ext-link[@ext-link-type='uri']")
+            for extlink in extlinks:
+                url_parts = list(urlsplit(extlink.attrib["href"]))
+                url_parts[2] = quote(url_parts[2])
+                extlink.attrib["href"] = urlunsplit(url_parts)
+            reflist.append(ref)
 
         return data
 

--- a/tests/test_export_sci.py
+++ b/tests/test_export_sci.py
@@ -1984,6 +1984,23 @@ class ExportTests(unittest.TestCase):
 
         self.assertEqual('articles', expected)
 
+    def test_doi_url_paths_are_quoted(self):
+        fake_article = self._article_meta
+        fake_article.data["citations"] = [{'v37': [{'_': 'https://doi.org/10.1671/0272-4634(2007)27[247:AESITS]2.0.CO;2'}]}]
+
+        pxml = ET.Element('articles')
+        pxml.append(ET.Element('article'))
+        article = pxml.find('article')
+        article.append(ET.Element('back'))
+        back = article.find('back')
+        back.append(ET.Element('ref-list'))
+
+        data = [fake_article, pxml]
+        raw, xml = export_sci.XMLArticleMetaCitationsPipe().transform(data)
+        expected = xml.xpath('//element-citation/ext-link')[0].attrib["href"]
+
+        self.assertEqual(u'https://doi.org/10.1671/0272-4634%282007%2927%5B247%3AAESITS%5D2.0.CO%3B2', expected)
+
 
 class ExportSci_XMLArticleMetaIssueInfoPipe_Tests(unittest.TestCase):
 


### PR DESCRIPTION
O documento http://www.scielo.br/scielo.php?script=sci_arttext&pid=S1516-35982019000100604&tlng=en
possui um referência bibliográfica com DOI https://doi.org/10.1671/0272-4634(2007)27[247:AESITS]2.0.CO;2.
Ao acessar este documento no articlemeta utilizando o formato `xmlwos` o XML
resultante é inválido em relação ao schema do web of science. A mensagem de
erro é a seguinte:

`Element 'ext-link', attribute 'href': 'https://doi.org/10.1671/0272-4634(2007)27[247:AESITS]2.0.CO;2'
is not a valid value of the atomic type 'xs:anyURI'., line 329`

Com esta mudança o *path* da URL do DOI passa a ser codificada, trocando
caracteres inválidos por suas sequências de escape correspondentes.

#### Onde a revisão poderia começar?
n/a

#### Como este poderia ser testado manualmente?
Na sua instância local do articlemeta acesse `/api/v1/article/?collection=scl&code=S1516-35982019000100604&format=xmlwos`. Compare o valor do atributo `ext-link/@href`, da referência bibliográfica de id _B9_. Antes de aplicar o patch você verá uma URL inválida, com colchetes (https://doi.org/10.1671/0272-4634(2007)27[247:AESITS]2.0.CO;2), que passará a ser codificada após a aplicação do _patch_. 

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
#208 

### Referências
n/a
