### PR TITLE
Corrige o código para resolver:  local variable 'abstract' referenced before assignment

### DIFF
--- a/articlemeta/export_rsps.py
+++ b/articlemeta/export_rsps.py
@@ -472,7 +472,7 @@ class XMLSubArticlePipe(plumber.Pipe):
                     abstract = ET.Element('abstract')
                     abstract.set('{http://www.w3.org/XML/1998/namespace}lang', lang)
                     abstract.append(p)
-                frontstub.append(abstract)
+                    frontstub.append(abstract)
 
             # KEYWORDS
             if raw.keywords():


### PR DESCRIPTION

#### O que esse PR faz?
Corrige o erro
```
04/02/2020 10:45:52  File "/usr/local/lib/python3.5/site-packages/articlemeta/export_rsps.py", line 475, in transform
04/02/2020 10:45:52    frontstub.append(abstract)
04/02/2020 10:45:52UnboundLocalError: local variable 'abstract' referenced before assignment
```
#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
Instanciando o Article com um json que contém abstracts de tradução, mas não tem o abstract no idioma correspondente ao idioma do sub-article. No caso deste documento, o erro também era no dado.

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
#206 

### Referências
n/a