### PR TITLE
Corrige a data de publicação para as citações nos formatos xmlwos e xmlrsps

### DIFF
--- a/articlemeta/export_rsps.py
+++ b/articlemeta/export_rsps.py
@@ -210,30 +210,28 @@ class XMLCitation(object):
         def precond(data):
             raw, xml = data
 
-            if not raw.date:
+            if not raw.publication_date:
                 raise plumber.UnmetPrecondition()
 
         @plumber.precondition(precond)
         def transform(self, data):
             raw, xml = data
 
-            pdate = ET.Element('date')
+            pdate = ET.Element("date")
 
-            if raw.date[8:10]:
-                day = ET.Element('day')
-                day.text = raw.date[8:10]
-                pdate.append(day)
+            date = {
+                "year": raw.publication_date[0:4],
+                "month": raw.publication_date[5:7],
+                "day": raw.publication_date[8:10],
+            }
 
-            if raw.date[5:7]:
-                month = ET.Element('month')
-                month.text = raw.date[5:7]
-                pdate.append(month)
+            for name, value in date.items():
+                if len(value) > 0 and value.isdigit() and int(value) > 0:
+                    date_element = ET.Element(name)
+                    date_element.text = value
+                    pdate.append(date_element)
 
-            year = ET.Element('year')
-            year.text = raw.date[0:4]
-            pdate.append(year)
-
-            xml.find('./element-citation').append(pdate)
+            xml.find("./element-citation").append(pdate)
 
             return data
 

--- a/articlemeta/export_sci.py
+++ b/articlemeta/export_sci.py
@@ -227,30 +227,28 @@ class XMLCitation(object):
         def precond(data):
             raw, xml = data
 
-            if not raw.date:
+            if not raw.publication_date:
                 raise plumber.UnmetPrecondition()
 
         @plumber.precondition(precond)
         def transform(self, data):
             raw, xml = data
 
-            pdate = ET.Element('date')
+            pdate = ET.Element("date")
 
-            if raw.date[8:10]:
-                day = ET.Element('day')
-                day.text = raw.date[8:10]
-                pdate.append(day)
+            date = {
+                "year": raw.publication_date[0:4],
+                "month": raw.publication_date[5:7],
+                "day": raw.publication_date[8:10],
+            }
 
-            if raw.date[5:7]:
-                month = ET.Element('month')
-                month.text = raw.date[5:7]
-                pdate.append(month)
+            for name, value in date.items():
+                if len(value) > 0 and value.isdigit() and int(value) > 0:
+                    date_element = ET.Element(name)
+                    date_element.text = value
+                    pdate.append(date_element)
 
-            year = ET.Element('year')
-            year.text = raw.date[0:4]
-            pdate.append(year)
-
-            xml.find('./element-citation').append(pdate)
+            xml.find("./element-citation").append(pdate)
 
             return data
 

--- a/tests/test_export_rsps.py
+++ b/tests/test_export_rsps.py
@@ -167,6 +167,76 @@ class XMLCitationTests(unittest.TestCase):
         self.assertEqual(u'04', expected_month)
         self.assertEqual(u'30', expected_day)
 
+    def test_xml_citation_should_not_includes_month_when_number_is_zero(self):
+        fakexylosearticle = Article(
+            {"article": {}, "title": {}, "citations": [{"v65": [{"_": "20060000"}]}]}
+        ).citations[0]
+
+        pxml = ET.Element("ref")
+        pxml.append(ET.Element("element-citation"))
+
+        data = [fakexylosearticle, pxml]
+
+        raw, xml = self._xmlcitation.DatePipe().transform(data)
+
+        expected_year = xml.find("./element-citation/date/year")
+        not_expected_month = xml.find("./element-citation/date/month")
+
+        self.assertEqual(u"2006", expected_year.text)
+        self.assertIsNone(not_expected_month)
+
+    def test_xml_citation_should_not_includes_day_when_number_is_zero(self):
+        fakexylosearticle = Article(
+            {"article": {}, "title": {}, "citations": [{"v65": [{"_": "20060000"}]}]}
+        ).citations[0]
+
+        pxml = ET.Element("ref")
+        pxml.append(ET.Element("element-citation"))
+
+        data = [fakexylosearticle, pxml]
+
+        raw, xml = self._xmlcitation.DatePipe().transform(data)
+
+        expected_year = xml.find("./element-citation/date/year")
+        not_expected_day = xml.find("./element-citation/date/day")
+
+        self.assertEqual(u"2006", expected_year.text)
+        self.assertIsNone(not_expected_day)
+
+    def test_xml_citation_should_not_includes_month_when_number_is_zero(self):
+        fakexylosearticle = Article(
+            {"article": {}, "title": {}, "citations": [{"v65": [{"_": "20060000"}]}]}
+        ).citations[0]
+
+        pxml = ET.Element("ref")
+        pxml.append(ET.Element("element-citation"))
+
+        data = [fakexylosearticle, pxml]
+
+        raw, xml = self._xmlcitation.DatePipe().transform(data)
+
+        expected_year = xml.find("./element-citation/date/year")
+        not_expected_month = xml.find("./element-citation/date/month")
+
+        self.assertEqual(u"2006", expected_year.text)
+        self.assertIsNone(not_expected_month)
+
+    def test_xml_citation_should_not_includes_year_when_number_is_zero(self):
+        fakexylosearticle = Article(
+            {"article": {}, "title": {}, "citations": [{"v65": [{"_": "00000000"}]}]}
+        ).citations[0]
+
+        pxml = ET.Element("ref")
+        pxml.append(ET.Element("element-citation"))
+
+        data = [fakexylosearticle, pxml]
+
+        raw, xml = self._xmlcitation.DatePipe().transform(data)
+
+        not_expected_year = xml.find("./element-citation/date/year")
+
+        self.assertIsNone(not_expected_year)
+
     def test_xml_citation_date_without_data_pipe(self):
 
         fakexylosearticle = Article({'article': {},

--- a/tests/test_export_sci.py
+++ b/tests/test_export_sci.py
@@ -296,6 +296,76 @@ class XMLCitationTests(unittest.TestCase):
         self.assertEqual(u'04', expected_month)
         self.assertEqual(u'30', expected_day)
 
+    def test_xml_citation_should_not_includes_month_when_number_is_zero(self):
+        fakexylosearticle = Article(
+            {"article": {}, "title": {}, "citations": [{"v65": [{"_": "20060000"}]}]}
+        ).citations[0]
+
+        pxml = ET.Element("ref")
+        pxml.append(ET.Element("element-citation"))
+
+        data = [fakexylosearticle, pxml]
+
+        raw, xml = self._xmlcitation.DatePipe().transform(data)
+
+        expected_year = xml.find("./element-citation/date/year")
+        not_expected_month = xml.find("./element-citation/date/month")
+
+        self.assertEqual(u"2006", expected_year.text)
+        self.assertIsNone(not_expected_month)
+
+    def test_xml_citation_should_not_includes_day_when_number_is_zero(self):
+        fakexylosearticle = Article(
+            {"article": {}, "title": {}, "citations": [{"v65": [{"_": "20060000"}]}]}
+        ).citations[0]
+
+        pxml = ET.Element("ref")
+        pxml.append(ET.Element("element-citation"))
+
+        data = [fakexylosearticle, pxml]
+
+        raw, xml = self._xmlcitation.DatePipe().transform(data)
+
+        expected_year = xml.find("./element-citation/date/year")
+        not_expected_day = xml.find("./element-citation/date/day")
+
+        self.assertEqual(u"2006", expected_year.text)
+        self.assertIsNone(not_expected_day)
+
+    def test_xml_citation_should_not_includes_month_when_number_is_zero(self):
+        fakexylosearticle = Article(
+            {"article": {}, "title": {}, "citations": [{"v65": [{"_": "20060000"}]}]}
+        ).citations[0]
+
+        pxml = ET.Element("ref")
+        pxml.append(ET.Element("element-citation"))
+
+        data = [fakexylosearticle, pxml]
+
+        raw, xml = self._xmlcitation.DatePipe().transform(data)
+
+        expected_year = xml.find("./element-citation/date/year")
+        not_expected_month = xml.find("./element-citation/date/month")
+
+        self.assertEqual(u"2006", expected_year.text)
+        self.assertIsNone(not_expected_month)
+
+    def test_xml_citation_should_not_includes_year_when_number_is_zero(self):
+        fakexylosearticle = Article(
+            {"article": {}, "title": {}, "citations": [{"v65": [{"_": "00000000"}]}]}
+        ).citations[0]
+
+        pxml = ET.Element("ref")
+        pxml.append(ET.Element("element-citation"))
+
+        data = [fakexylosearticle, pxml]
+
+        raw, xml = self._xmlcitation.DatePipe().transform(data)
+
+        not_expected_year = xml.find("./element-citation/date/year")
+
+        self.assertIsNone(not_expected_year)
+
     def test_xml_citation_date_without_data_pipe(self):
 
         fakexylosearticle = Article({'article': {},


### PR DESCRIPTION
#### O que esse PR faz?

Este pull request altera o método utilizado para recupera a data das citações nos formatos `xmlwos` e `xmlrsps`.

#### Onde a revisão poderia começar?
- `articlemeta/export_rsps.py` L: `213`
- `articlemeta/export_sci.py` L: `231`

#### Como este poderia ser testado manualmente?
Para testar este pull request manualmente, deve-se:
- Acesse as páginas:
  - [formato xml rsps](http://articlemeta.scielo.org/api/v1/article/?collection=scl&code=S0001-37652008000100006&format=xmlrsps)
  - [formato xml wos](http://articlemeta.scielo.org/api/v1/article/?collection=scl&code=S0001-37652008000100006&format=xmlwos)
- Verifique se as datas da referência `B25` estão de acordo com o requerido (apenas o ano).

#### Algum cenário de contexto que queira dar?
N/A

### Screenshots
N/A

#### Quais são tickets relevantes?
closes #187 

### Referências
N/A
