### PR TITLE
 Corrige a data de publicação para as citações no formato xmlcrossref

### DIFF
--- a/articlemeta/export_crossref.py
+++ b/articlemeta/export_crossref.py
@@ -893,17 +893,19 @@ class XMLCitation(object):
         def precond(data):
             raw, xml = data
 
-            if not raw.date:
+            if not raw.publication_date:
                 raise plumber.UnmetPrecondition()
 
         @plumber.precondition(precond)
         def transform(self, data):
             raw, xml = data
 
-            pdate = ET.Element('cYear')
-            pdate.text = raw.date[0:4]
+            year = raw.publication_date[0:4]
 
-            xml.find('.').append(pdate)
+            if len(year) > 0 and year.isdigit() and int(year) > 0:
+                pdate = ET.Element("cYear")
+                pdate.text = year
+                xml.find(".").append(pdate)
 
             return data
 

--- a/tests/test_export_crossref.py
+++ b/tests/test_export_crossref.py
@@ -608,6 +608,37 @@ class ExportCrossRef_one_DOI_only_Tests(unittest.TestCase):
             self.assertIsNotNone(programs)
 
 
+    def test_date_pipe_should_includes_year_when_it_is_valid(self):
+        doi_batch = create_xmlcrossref_with_n_journal_article_element(["pt"])
+        self._raw_json["citations"] = [{"v65": [{"_": "20060320"}]}]
+        article_json = Article(self._raw_json)
+        data = [article_json, doi_batch]
+
+        xmlcrossref = export_crossref.XMLArticleCitationsPipe()
+        raw, xml = xmlcrossref.transform(data)
+
+        self.assertIsNotNone(xml.find(".//citation"))  # ensure citation
+
+        expected_c_year = xml.find(".//cYear")
+
+        self.assertIsNotNone(expected_c_year)
+        self.assertEqual(u"2006", expected_c_year.text)
+
+    def test_date_pipe_should_not_includes_year_when_it_is_zero(self):
+        doi_batch = create_xmlcrossref_with_n_journal_article_element(["pt"])
+        self._raw_json["citations"] = [{"v65": [{"_": "0000"}]}]
+        article_json = Article(self._raw_json)
+        data = [article_json, doi_batch]
+
+        xmlcrossref = export_crossref.XMLArticleCitationsPipe()
+        raw, xml = xmlcrossref.transform(data)
+
+        self.assertIsNotNone(xml.find(".//citation"))  # ensure citation
+
+        not_expected_c_year = xml.find(".//cYear")
+
+        self.assertIsNone(not_expected_c_year)
+
 class ExportCrossRef_MultiLingueDoc_with_MultipleDOI_Tests(unittest.TestCase):
 
     def setUp(self):


### PR DESCRIPTION
#### O que esse PR faz?

Este pull request corrigue a data de publicação para as citações quando o artigo é exportado no formato `xmlcrossref`.

#### Onde a revisão poderia começar?
- `articlemeta/export_crossref.py`

#### Como este poderia ser testado manualmente?
Para testar este pull request manualmente, deve-se:
- Acesse a URL `api/v1/article/?collection=scl&code=S0001-37652008000100006&format=xmlcrossref`;
- Verifique a referência `25`;
- Observe que o ano de publicação em `cYear` é `1985`;

#### Algum cenário de contexto que queira dar?
N/A

### Screenshots
N/A

#### Quais são tickets relevantes?
closes #187 

### Referências
N/A
