### PR TITLE
Adiciona fpage/@seq ao formato xmlrsps

### DIFF
--- a/articlemeta/export_rsps.py
+++ b/articlemeta/export_rsps.py
@@ -935,6 +935,10 @@ class XMLArticleMetaPagesInfoPipe(plumber.Pipe):
         fpage = ET.Element('fpage')
         fpage.text = raw.start_page
 
+        seq = raw.start_page_sequence
+        if seq:
+            fpage.set("seq", seq)
+
         lpage = ET.Element('lpage')
         lpage.text = raw.end_page
 

--- a/tests/test_export_rsps.py
+++ b/tests/test_export_rsps.py
@@ -1199,6 +1199,31 @@ class ExportTests(unittest.TestCase):
 
         self.assertEqual(u'639', fpage)
 
+    def test_xmlarticle_meta_general_info_first_page_with_seq(self):
+
+        pxml = ET.Element('article')
+        pxml.append(ET.Element('front'))
+
+        front = pxml.find('front')
+        front.append(ET.Element('article-meta'))
+        self._article_meta.data['article']['v14'] = [
+            {
+                "l": "610",
+                "s": "34",
+                "_": "",
+                "f": "609"
+            }
+        ]
+
+        data = [self._article_meta, pxml]
+
+        xmlarticle = export_rsps.XMLArticleMetaPagesInfoPipe()
+        raw, xml = xmlarticle.transform(data)
+
+        fpage = xml.find('./front/article-meta/fpage')
+
+        self.assertEqual(u'34', fpage.attrib["seq"])
+
     def test_xmlarticle_meta_general_info_without_first_page_pipe(self):
 
         del(self._article_meta.data['article']['v14'][0]['f'])


### PR DESCRIPTION
Adiciona o atributo `fpage/@seq` no _front_ do formato _xmlrsps_ quando este valor estiver disponível.

O valor do atributo `@seq` é importante para desambiguar documentos que
iniciam numa mesma página de um mesmo fascículo.

#### Onde a revisão poderia começar?
n/a

#### Como este poderia ser testado manualmente?
Após aplicar o _patch_, teste com o documento `/api/v1/article/?body=false&collection=scl&code=S0001-37652000000400034&format=xmlrsps`, conforme descrito no ticket #213.

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
#213 

### Referências
n/a
