### PR TITLE
Corrige a carga das mixed citations

### DIFF
--- a/processing/load_mixedcitations.py
+++ b/processing/load_mixedcitations.py
@@ -16,7 +16,7 @@ from xylose.scielodocument import Article
 logger = logging.getLogger(__name__)
 SENTRY_DSN = os.environ.get('SENTRY_DSN', None)
 LOGGING_LEVEL = os.environ.get('LOGGING_LEVEL', 'DEBUG')
-MONGODB_HOST = os.environ.get('MONGODB_HOST', None)
+MONGODB_HOST = os.environ.get('MONGODB_HOST', 'mongodb://localhost:27017/articlemeta')
 
 DOI_REGEX = re.compile(r'[0-9][0-9]\.[0-9].*/.*\S')
 
@@ -60,9 +60,10 @@ if SENTRY_DSN:
 
 
 try:
-    articlemeta_db = controller.DataBroker.from_dsn(MONGODB_HOST).db
+    articlemeta_db = controller.get_dbconn(MONGODB_HOST)
 except:
-    logger.error('Fail to connect to (%s)', MONGODB_HOST)
+    print('Fail to connect to:', MONGODB_HOST)
+    sys.exit(1)
 
 
 def remove_control_characters(data):

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ thriftpy==0.3.9
 urllib3==1.22
 venusian==1.1.0
 WebOb==1.8.0rc1
--e git+https://github.com/scieloorg/xylose.git@1.35.8#egg=xylose
+-e git+https://github.com/scieloorg/xylose.git@1.35.9#egg=xylose
 zope.deprecation==4.3.0
 zope.interface==4.4.3
 crossrefapi==1.3.0

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
     ],
     dependency_links=[
         "git+https://github.com/scieloorg/thriftpy-wrap@0.1.1#egg=thriftpywrap",
-        "git+https://github.com/scieloorg/xylose.git@1.35.8#egg=xylose",
+        "git+https://github.com/scieloorg/xylose.git@1.35.9#egg=xylose",
     ],
     include_package_data=True,
     zip_safe=False,


### PR DESCRIPTION
#### O que esse PR faz?

Este pull request melhora a combinação dos títulos durante a fase de auditoria, porque algumas citações deixavam de ser carregadas por ter tags entre palavras ou espaços em demasia. Escapa a "tag" <http presente em alguns artigos de forma errônea. Também modifica o namespace `w` para que seja possível ter uma citação válida.

#### Onde a revisão poderia começar?
- `processing/load_mixedcitations.py`

#### Como este poderia ser testado manualmente?

Para testar este pull requests manualmente, deve-se:
- Baixe as citações [1];
- Faça a carga em uma instância do *AM*.
- Verifique que as citações foram carregadas com sucesso e que as tags foram escapadas de maneira adequada.

#### Algum cenário de contexto que queira dar?
Alguns artigos não poderão ser exibidos em sua plenitude porque dependem de um outro pull request para corrigir o [xylose](https://github.com/scieloorg/xylose/pull/190).

### Screenshots
N/A

#### Quais são tickets relevantes?
#217

### Anexos

[[1] - mixed citations dos artigos](https://drive.google.com/open?id=18Dzx--8CDcInbCURZq9j5MxUP-t6pjhg)

### Referências
N/A
