### PR TITLE
Corrige a carga do HTML quando falsas tags <http> são encontradas

### DIFF
--- a/processing/__init__.py
+++ b/processing/__init__.py
@@ -1,0 +1,19 @@
+import re
+import html
+
+HTTP_SCAPE_CHARS = re.compile(".*(<http.*?>|<http.*?>?).*", re.MULTILINE)
+
+def escape_html_http_tags(string):
+    """Escapa trechos de uma string que podem ser interpretadas como tags HTML.
+
+    >>> escape_html_http_tags("Citação disponível em <http://www.scielo.br>.")
+    >>> "Citação disponível em &lt;http://www.scielo.br&gt;."
+    >>> escape_html_http_tags("Citação disponível em <http://www.scielo.br")
+    >>> "Citação disponível em &lt;http://www.scielo.br"
+    """
+
+    while HTTP_SCAPE_CHARS.match(string):
+        match = HTTP_SCAPE_CHARS.match(string)
+        http_string = match.groups()[0]
+        string = string.replace(http_string, html.escape(http_string))
+    return string

--- a/processing/load_body.py
+++ b/processing/load_body.py
@@ -19,6 +19,7 @@ from io import StringIO
 from xylose.scielodocument import Article
 
 from articlemeta import controller
+from processing import escape_html_http_tags
 
 
 logger = logging.getLogger(__name__)
@@ -168,6 +169,7 @@ def scrap_body(data, language):
     data = data.decode(encoding, 'replace')
 
     data = ' '.join([i.strip() for i in data.split('\n')])
+    data = escape_html_http_tags(data)
 
     parser = etree.HTMLParser(remove_blank_text=True)
     tree = etree.parse(StringIO(data), parser)

--- a/tests/test_load_languages.py
+++ b/tests/test_load_languages.py
@@ -10,6 +10,23 @@ from processing import load_languages
 from articlemeta import controller
 
 
+def mock_static_catalog_init_method(self, collection):
+    self.catalog = {
+        "rsp": {
+            "v52": {
+                'html': [],
+                'pdf': [
+                    '0034-8910-rsp-s1518-87872018052000131-pt',
+                    '0034-8910-rsp-s1518-87872018052000131',
+                    'pt_0034-8910-rsp-s1518-87872018052000131'
+                ],
+                'xml': [
+                    '0034-8910-rsp-s1518-87872018052000131'
+                ]
+            }
+        }
+    }
+
 class LoadLanguageTest(TestCase):
 
     def setUp(self):
@@ -63,6 +80,9 @@ class LoadLanguageTest(TestCase):
             ['mioc', 'v82s3', 'vol82(fsup3)_ii']
         )
 
+    @patch.object(
+        load_languages.StaticCatalog, "__init__", mock_static_catalog_init_method
+    )
     def test_run(self):
         mocked_articlemeta_db = mongomock.MongoClient().db
         mocked_articlemeta_db['collections'].insert_many([

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,7 @@
 import unittest
 from lxml import etree
 from articlemeta.utils import convert_ahref_to_extlink
+from processing import escape_html_http_tags
 
 
 class TestConvertAtoExtlink(unittest.TestCase):
@@ -21,3 +22,20 @@ class TestConvertAtoExtlink(unittest.TestCase):
         xml_etree = convert_ahref_to_extlink(self.etree_with_links)
         self.assertEqual(1, len(xml_etree.findall(".//ext-link")))
 
+
+class TestProcessingEscapeHTTPTags(unittest.TestCase):
+
+    def test_should_escape_http_tags(self):
+        string = "<http://www.scielo.br>Texto"
+        expected = "&lt;http://www.scielo.br&gt;Texto"
+        self.assertEqual(expected, escape_html_http_tags(string))
+
+    def test_should_escape_all_html_tags_in_the_string(self):
+        string = "<http://www.scielo.br>Texto<p><https://www.scielo.org></p>"
+        expected = "&lt;http://www.scielo.br&gt;Texto<p>&lt;https://www.scielo.org&gt;</p>"
+        self.assertEqual(expected, escape_html_http_tags(string))
+
+    def test_should_not_scape_regular_tags_or_texts(self):
+        string = "<p>Some text available in &lt;http://www.scielo.br&gt;</p>"
+        expected = "<p>Some text available in &lt;http://www.scielo.br&gt;</p>"
+        self.assertEqual(expected, escape_html_http_tags(string))


### PR DESCRIPTION
#### O que esse PR faz?

Este pull request aplica uma função para escapar as falsas tags `<http>` durante a carga dos HTMLs pelo A.M. O processo consiste em alterar a string capturada durante a requisição HTTP, substituindo `<http>` por `&lt;http&gt;`.

#### Onde a revisão poderia começar?
- Pelo commit `e9986ef`

#### Como este poderia ser testado manualmente?
- Baixe o arquivo [S0104-87752008000100005.txt](https://github.com/scieloorg/articles_meta/files/5960789/S0104-87752008000100005.txt);
- Carregue-o no seu mongodb com o comando `mongoimport --db articlemeta --collection articles --file S0104-87752008000100005.txt`
- Execute o comando `python processing/load_body.py --logging_level DEBUG -p S0104-87752008000100005 -c sc`
- Acesse o artigo no seu [A.M](http://localhost:8000/api/v1/article/?collection=scl&code=S0104-87752008000100005&format=xylose&body=true);
- Verifique que os locais onde antes tínhamos `<http>` foram substituídos por `&lt;http&gt;`.


#### Algum cenário de contexto que queira dar?
N/A

### Screenshots
N/A

#### Quais são tickets relevantes?
#223

### Referências
N/A
