### PR TITLE
Fix the absence of elements to identify has translation and is translation of

### DIFF
--- a/articlemeta/export.py
+++ b/articlemeta/export.py
@@ -206,8 +206,8 @@ class Export(object):
             export_crossref.XMLArticleAbstractPipe(),
             export_crossref.XMLArticlePubDatePipe(),
             export_crossref.XMLPagesPipe(),
-            export_crossref.XMLElocationPipe(),
             export_crossref.XMLPIDPipe(),
+            export_crossref.XMLElocationPipe(),
             export_crossref.XMLPermissionsPipe(),
             export_crossref.XMLProgramRelatedItemPipe(),
             export_crossref.XMLDOIDataPipe(),
@@ -215,7 +215,6 @@ class Export(object):
             export_crossref.XMLResourcePipe(),
             export_crossref.XMLCollectionPipe(),
             export_crossref.XMLArticleCitationsPipe(),
-            
             export_crossref.XMLClosePipe()
         )
 

--- a/articlemeta/export.py
+++ b/articlemeta/export.py
@@ -206,14 +206,16 @@ class Export(object):
             export_crossref.XMLArticleAbstractPipe(),
             export_crossref.XMLArticlePubDatePipe(),
             export_crossref.XMLPagesPipe(),
+            export_crossref.XMLElocationPipe(),
             export_crossref.XMLPIDPipe(),
             export_crossref.XMLPermissionsPipe(),
-            export_crossref.XMLElocationPipe(),
+            export_crossref.XMLProgramRelatedItemPipe(),
             export_crossref.XMLDOIDataPipe(),
             export_crossref.XMLDOIPipe(),
             export_crossref.XMLResourcePipe(),
             export_crossref.XMLCollectionPipe(),
             export_crossref.XMLArticleCitationsPipe(),
+            
             export_crossref.XMLClosePipe()
         )
 

--- a/articlemeta/export_crossref.py
+++ b/articlemeta/export_crossref.py
@@ -331,6 +331,25 @@ class XMLArticleTitlesPipe(plumber.Pipe):
         return data
 
 
+def title_doi_lang(raw):
+    items = {}
+
+    items[raw.original_language()] = {
+        "article_title": raw.original_title(),
+        "doi": raw.doi,
+        "original": True,
+    }
+    for lang, article_title in (raw.translated_titles() or {}).items():
+        items[lang] = items.get(lang) or {}
+        items[lang]["article_title"] = article_title
+
+    for lang, doi in raw.doi_and_lang:
+        items[lang] = items.get(lang) or {}
+        items[lang]["doi"] = doi
+
+    return items
+
+
 class XMLArticleTitlePipe(plumber.Pipe):
 
     def transform(self, data):

--- a/articlemeta/export_crossref.py
+++ b/articlemeta/export_crossref.py
@@ -1096,7 +1096,7 @@ class XMLClosePipe(plumber.Pipe):
         return data
 
 
-class XMLProgramPipe(plumber.Pipe):
+class XMLProgramRelatedItemPipe(plumber.Pipe):
 
     def transform(self, data):
         raw, xml = data
@@ -1107,16 +1107,18 @@ class XMLProgramPipe(plumber.Pipe):
     def _transform_original(self, data):
         raw, xml = data
 
+        # first journal_article (main)
         journal_article_node = xml.find('.//journal_article')
 
-        doi_and_lang = raw.doi_and_lang[1:]
-
         # program
-        program_node = ET.Element('program')
+        program_node = ET.Element("program")
         program_node.set('xmlns',  'http://www.crossref.org/relations.xsd')
 
+        original_language = raw.original_language()
         translated_titles = raw.translated_titles()
-        for lang, doi in doi_and_lang:
+        for lang, doi in raw.doi_and_lang:
+            if lang == original_language:
+                continue
 
             # program/related_item
             related_item_node = ET.Element('related_item')
@@ -1144,7 +1146,7 @@ class XMLProgramPipe(plumber.Pipe):
         raw, xml = data
 
         # program
-        program_node = ET.Element('program')
+        program_node = ET.Element("program")
         program_node.set('xmlns',  'http://www.crossref.org/relations.xsd')
 
         # program/related_item
@@ -1158,7 +1160,7 @@ class XMLProgramPipe(plumber.Pipe):
         # program/related_item/intra_work_relation
         intra_work_relation_node = ET.Element('intra_work_relation')
         intra_work_relation_node.set(
-            'relationship-type', 'isTranslationOf')
+            'relationship-type', 'hasTranslation')
         intra_work_relation_node.set('identifier-type', 'doi')
         intra_work_relation_node.text = raw.doi
         related_item_node.append(intra_work_relation_node)

--- a/tests/test_export_crossref.py
+++ b/tests/test_export_crossref.py
@@ -11,6 +11,102 @@ from articlemeta import export
 from articlemeta.export import CustomArticle as Article
 
 
+def _get_article(data=None):
+    article_json = {
+        "fulltexts": {
+            "pdf": {
+                "es": "http://www.scielo.br/pdf/rsp/v44n4/es_07.pdf",
+                "en": "http://www.scielo.br/pdf/rsp/v44n4/en_07.pdf",
+                "pt": "http://www.scielo.br/pdf/rsp/v44n4/07.pdf"
+            },
+            "html": {
+                "es": "http://www.scielo.br/scielo.php?script=sci_arttext&pid=S0034-89102010000400007&tlng=es",
+                "en": "http://www.scielo.br/scielo.php?script=sci_arttext&pid=S0034-89102010000400007&tlng=en",
+                "pt": "http://www.scielo.br/scielo.php?script=sci_arttext&pid=S0034-89102010000400007&tlng=pt"
+            }
+        },
+        "collection": "scl",
+        "doi": "10.1590/S0034-89102010000400007",
+        "body": {
+            "pt": "Body PT",
+            "es": "Body ES",
+            "en": "Body EN"
+        },
+        "article": {
+            "v880": [
+                {
+                    "_": "S0034-89102010000400007"
+                }
+            ],
+            "v237": [
+                {
+                    "_": "10.1590/S0034-89102010000400007"
+                }
+            ],
+
+
+            "v40": [
+                {
+                    "_": "pt"
+                }
+            ],
+
+            "v12": [
+                {
+                    "l": "pt",
+                    "_": "Perfil epidemiológico dos pacientes em terapia"
+                    " renal substitutiva no Brasil, 2000-2004"
+                },
+                {
+                    "l": "en",
+                    "_": "Epidemiological profile of patients on"
+                    " renal replacement therapy in Brazil, 2000-2004"
+                },
+                {
+                    "l": "es",
+                    "_": "Perfil epidemiológico de los pacientes en terapia"
+                    " renal substitutiva en Brasil, 2000-2004"
+                }
+            ],
+            "v337": [
+                {
+                    "l": "pt",
+                    "d": "10.1590/S0034-89102010000400007",
+                },
+                {
+                    "l": "es",
+                    "d": "10.1590/ID.es"
+                }
+
+            ],
+            "v83": [
+                {
+                    "a": "OBJETIVO: Descrever o perfil epidemiol\u00f3gico e cl\u00ednico de pacientes em terapia renal substitutiva, identificando fatores associados ao risco de morte. M\u00c9TODOS: Estudo observacional, prospectivo n\u00e3o concorrente, a partir de dados de 90.356 pacientes da Base Nacional em Terapias Renais Substitutivas, no Brasil. Foi realizado relacionamento determin\u00edstico-probabil\u00edstico do Sistema de Autoriza\u00e7\u00e3o de Procedimentos de Alta Complexidade/Custo e do Sistema de Informa\u00e7\u00e3o de Mortalidade. Foram inclu\u00eddos todos os pacientes incidentes que iniciaram di\u00e1lise entre 1/1/2000 e 31/12/2004, acompanhados at\u00e9 a morte ou final de 2004. Idade, sexo, regi\u00e3o de resid\u00eancia, doen\u00e7a renal prim\u00e1ria, causa do \u00f3bito foram analisados. Ajustou-se um modelo de riscos proporcionais para identificar fatores associados ao risco de morte. RESULTADOS: Ocorreu um aumento m\u00e9dio de 5,5% na preval\u00eancia de pacientes em terapia enquanto a incid\u00eancia manteve-se est\u00e1vel no per\u00edodo. Hemodi\u00e1lise foi a modalidade inicial predominante (89%). A maioria dos pacientes era do sexo masculino, com idade m\u00e9dia de 53 anos, residente na regi\u00e3o Sudeste, e apresentava causa indeterminada como principal causa b\u00e1sica da doen\u00e7a renal cr\u00f4nica, seguida da hipertens\u00e3o, diabetes e glomerulonefrites. Desses pacientes, 7% realizou transplante renal e 42% evoluiu para o \u00f3bito. Os pacientes em di\u00e1lise peritoneal eram mais idosos e apresentavam maior preval\u00eancia de diabetes. Entre os n\u00e3o transplantados, 45% foi a \u00f3bito e, entre os transplantados, 7%. No modelo final de riscos proporcionais de Cox, o risco de mortalidade foi associado com o aumento da idade, sexo feminino, ter diabetes, residir nas regi\u00f5es Norte e Nordeste, di\u00e1lise peritoneal como modalidade de entrada e n\u00e3o ter realizado transplante renal. CONCLUS\u00d5ES: Houve aumento da preval\u00eancia de pacientes em terapia renal no Brasil. Pacientes com idade avan\u00e7ada, diabetes, do sexo feminino, residentes nas regi\u00f5es Norte e Nordeste e sem transplante renal apresentam maior risco de morte.",
+                    "l": "pt",
+                    "_": ""
+                },
+                {
+                    "a": "OBJECTIVE: To describe the clinical and epidemiological profile of patients under renal replacement therapies, identifying risk factors for death. METHODS: This is a non-concurrent cohort study of data for 90,356 patients in the National Renal Replacement Therapies Database. A deterministic-probabilistic linkage was performed using the Authorization System for High Complexity/Cost Procedures and the Mortality Information System databases. All patients who started dialysis between 1/1/2000 and 12/31/2004 were included and followed until death or the end of 2004. Age, sex, region of residence, primary renal disease and causes of death were analyzed. A proportional hazards model was used to identify factors associated with risk of death. RESULTS: The prevalence of patients under renal replacement therapies increased an average of 5.5%, while incidence remained stable during the period. Hemodialysis was the predominant initial modality (89%). The patients were majority male with mean age 53 years, residents of the Southeast region and presented unknown causes as the main cause of chronic renal disease, followed by hypertension, diabetes and glomerulonephritis. Of these patients, 42% progressed to death and 7% underwent kidney transplantation. The patients on peritoneal dialysis were older and had higher prevalence of diabetes. The death rate varied from 7% among transplanted patients to 45% among non-transplanted patients. In the final Cox proportional hazards model, the risk of mortality was associated with increasing age, female sex, having diabetes, living in the North and Northeast region, peritoneal dialysis as a first modality and not having renal transplantation. CONCLUSIONS: There was an increased prevalence of patients on renal therapy in Brazil. Increased risk of death was associated with advanced age, diabetes, the female sex, residents of the North and Northeast region and lack of renal transplant.",
+                    "l": "en",
+                    "_": ""
+                },
+                {
+                    "a": "OBJETIVO: Describir el perfil epidemiol\u00f3gico y cl\u00ednico de pacientes en terapia renal substitutiva, identificando factores asociados al riesgo de muerte. M\u00c9TODOS: Estudio de observaci\u00f3n, prospectivo no concurrente, a partir de datos de 90.356 pacientes de la Base Nacional en Terapias Renales Substitutivas, en Brasil. Fue realizado reracionamiento determin\u00edstico-probabil\u00edstico del Sistema de Informaci\u00f3n de Mortalidad. Fueron incluidos todos los pacientes incidentes que iniciaron di\u00e1lisis entre 1/1/2000 y 31/12/2004, acompa\u00f1ados hasta la muerte o final de 2004. Edad, sexo, regi\u00f3n de residencia, enfermedad renal primaria, causa del \u00f3bito fueron analizados. Se ajust\u00f3 un modelo de riesgos proporcionales para identificar factores asociados al riesgo de muerte. RESULTADOS: Ocurri\u00f3 un aumento promedio de 5,5% en la prevalencia de pacientes en terapia, con relaci\u00f3n a la incidencia se mantuvo estable en el per\u00edodo. Hemodi\u00e1lisis fue la modalidad inicial predominante (89%). La mayor\u00eda de los pacientes era del sexo masculino, con edad promedio de 53 a\u00f1os, residente en la regi\u00f3n Sureste y presentaba causa indeterminada como principal causa b\u00e1sica de la enfermedad renal cr\u00f3nica, seguida de la hipertensi\u00f3n, diabetes y glomerulonefritis. De esos pacientes, 7% realizaron transplante renal y 42% evolucionaron a \u00f3bito. Los pacientes en di\u00e1lisis peritoneal eran m\u00e1s ancianos y presentaban mayor prevalencia de diabetes. Entre los no transplantados, 45% fueron a \u00f3bito y, entre los transplantadas 7%. En el modelo final de riesgos proporcionales de Cox, el riesgo de mortalidad estuvo asociado con el aumento de la edad, sexo femenino, tener diabetes, residir en la regi\u00f3n Norte y Noreste, di\u00e1lisis peritoneal como modalidad de entrada y no haber realizado transplante renal. CONCLUSIONES: Hubo aumento de la prevalencia de pacientes en terapia renal en Brasil. Pacientes con edad avanzada, diabetes, del sexo femenino, residentes en la regi\u00f3n Norte y Noreste y sin transplante renal presentan mayor riesgo de muerte.",
+                    "l": "es",
+                    "_": ""
+                }
+            ]
+        },
+
+        "issue": {
+            "issue": {},
+        },
+    }
+    data = data or {}
+    article_json["article"].update(data)
+    return Article(article_json)
+
+
 def create_xmlcrossref_with_journal_element(journal_child_name=None):
     xmlcrossref = ET.Element('doi_batch')
     journal = ET.Element('journal')
@@ -41,6 +137,93 @@ def create_xmlcrossref_with_n_journal_article_element(
 
     xmlcrossref.append(body)
     return xmlcrossref
+
+
+class ExportCrossRefTitleDoiLangTests(unittest.TestCase):
+
+    def setUp(self):
+        self._article = _get_article()
+
+    def test_title_doi_lang_for_article_which_has_one_doi_and_one_title(self):
+        data = {"v337": [], "v12": []}
+        data["v12"] = [
+            {
+                "l": "pt",
+                "_": (
+                    "Perfil epidemiológico dos pacientes em terapia"
+                    " renal substitutiva no Brasil, 2000-2004"
+                )
+            }
+        ]
+        article = _get_article(data)
+        expected = {
+            "pt": {
+                "article_title": (
+                    "Perfil epidemiológico dos pacientes em terapia"
+                    " renal substitutiva no Brasil, 2000-2004"
+                ),
+                "doi": "10.1590/S0034-89102010000400007",
+                "original": True,
+            }
+        }
+        result = export_crossref.title_doi_lang(article)
+        self.assertEqual(expected, result)
+
+    def test_title_doi_lang_for_article_which_has_one_doi_and_titles(self):
+        data = {"v337": []}
+        article = _get_article(data)
+        expected = {
+            "pt": {
+                "article_title": (
+                    "Perfil epidemiológico dos pacientes em terapia"
+                    " renal substitutiva no Brasil, 2000-2004"
+                ),
+                "doi": "10.1590/S0034-89102010000400007",
+                "original": True,
+            },
+            "en": {
+                "article_title": (
+                    "Epidemiological profile of patients on"
+                    " renal replacement therapy in Brazil, 2000-2004"
+                )
+            },
+            "es": {
+                "article_title": (
+                    "Perfil epidemiológico de los pacientes en terapia"
+                    " renal substitutiva en Brasil, 2000-2004"
+                )
+            }
+        }
+        result = export_crossref.title_doi_lang(article)
+        self.assertEqual(expected, result)
+
+    def test_title_doi_lang_for_article_which_has_multiple_dois_and_titles(self):
+        article = _get_article()
+        expected = {
+            "pt": {
+                "article_title": (
+                    "Perfil epidemiológico dos pacientes em terapia"
+                    " renal substitutiva no Brasil, 2000-2004"
+                ),
+                "doi": "10.1590/S0034-89102010000400007",
+                "original": True,
+            },
+            "en": {
+                "article_title": (
+                    "Epidemiological profile of patients on"
+                    " renal replacement therapy in Brazil, 2000-2004"
+                )
+            },
+            "es": {
+                "article_title": (
+                    "Perfil epidemiológico de los pacientes en terapia"
+                    " renal substitutiva en Brasil, 2000-2004"
+                ),
+                "doi": "10.1590/ID.es",
+            }
+        }
+        result = export_crossref.title_doi_lang(article)
+        self.assertEqual(expected, result)
 
 
 class ExportCrossRef_one_DOI_only_Tests(unittest.TestCase):

--- a/tests/test_export_crossref.py
+++ b/tests/test_export_crossref.py
@@ -659,7 +659,6 @@ class ExportCrossRef_one_DOI_only_Tests(unittest.TestCase):
         schema_root = ET.parse(fp)
         schema = ET.XMLSchema(schema_root)
         fp.close()
-        print(ET.tostring(xmlio))
 
         schema.assertValid(xmlio)
         self.assertTrue(schema.validate(xmlio))

--- a/tests/test_export_crossref.py
+++ b/tests/test_export_crossref.py
@@ -125,7 +125,7 @@ def create_xmlcrossref_with_n_journal_article_element(
     xmlcrossref = ET.Element('doi_batch')
     body = ET.Element('body')
     journal = ET.Element('journal')
-    for lang, doi in languages:
+    for lang in languages:
         journal_article = ET.Element('journal_article')
         journal_article.set('language', lang)
         journal_article.set('publication_type', 'full_text')
@@ -659,9 +659,9 @@ class ExportCrossRef_one_DOI_only_Tests(unittest.TestCase):
         schema_root = ET.parse(fp)
         schema = ET.XMLSchema(schema_root)
         fp.close()
+        print(ET.tostring(xmlio))
 
         schema.assertValid(xmlio)
-
         self.assertTrue(schema.validate(xmlio))
         self.assertEqual(None, schema.assertValid(xmlio))
 
@@ -927,17 +927,17 @@ class ExportCrossRef_MultiLingueDoc_with_MultipleDOI_Tests(unittest.TestCase):
                 ],
                 "v83": [
                     {
-                        "a": "OBJETIVO: Descrever o perfil epidemiol\u00f3gico e cl\u00ednico de pacientes em terapia renal substitutiva, identificando fatores associados ao risco de morte. M\u00c9TODOS: Estudo observacional, prospectivo n\u00e3o concorrente, a partir de dados de 90.356 pacientes da Base Nacional em Terapias Renais Substitutivas, no Brasil. Foi realizado relacionamento determin\u00edstico-probabil\u00edstico do Sistema de Autoriza\u00e7\u00e3o de Procedimentos de Alta Complexidade/Custo e do Sistema de Informa\u00e7\u00e3o de Mortalidade. Foram inclu\u00eddos todos os pacientes incidentes que iniciaram di\u00e1lise entre 1/1/2000 e 31/12/2004, acompanhados at\u00e9 a morte ou final de 2004. Idade, sexo, regi\u00e3o de resid\u00eancia, doen\u00e7a renal prim\u00e1ria, causa do \u00f3bito foram analisados. Ajustou-se um modelo de riscos proporcionais para identificar fatores associados ao risco de morte. RESULTADOS: Ocorreu um aumento m\u00e9dio de 5,5% na preval\u00eancia de pacientes em terapia enquanto a incid\u00eancia manteve-se est\u00e1vel no per\u00edodo. Hemodi\u00e1lise foi a modalidade inicial predominante (89%). A maioria dos pacientes era do sexo masculino, com idade m\u00e9dia de 53 anos, residente na regi\u00e3o Sudeste, e apresentava causa indeterminada como principal causa b\u00e1sica da doen\u00e7a renal cr\u00f4nica, seguida da hipertens\u00e3o, diabetes e glomerulonefrites. Desses pacientes, 7% realizou transplante renal e 42% evoluiu para o \u00f3bito. Os pacientes em di\u00e1lise peritoneal eram mais idosos e apresentavam maior preval\u00eancia de diabetes. Entre os n\u00e3o transplantados, 45% foi a \u00f3bito e, entre os transplantados, 7%. No modelo final de riscos proporcionais de Cox, o risco de mortalidade foi associado com o aumento da idade, sexo feminino, ter diabetes, residir nas regi\u00f5es Norte e Nordeste, di\u00e1lise peritoneal como modalidade de entrada e n\u00e3o ter realizado transplante renal. CONCLUS\u00d5ES: Houve aumento da preval\u00eancia de pacientes em terapia renal no Brasil. Pacientes com idade avan\u00e7ada, diabetes, do sexo feminino, residentes nas regi\u00f5es Norte e Nordeste e sem transplante renal apresentam maior risco de morte.",
+                        "a": "OBJETIVO: Descrever o perfil epidemiol\u00f3gico...",
                         "l": "pt",
                         "_": ""
                     },
                     {
-                        "a": "OBJECTIVE: To describe the clinical and epidemiological profile of patients under renal replacement therapies, identifying risk factors for death. METHODS: This is a non-concurrent cohort study of data for 90,356 patients in the National Renal Replacement Therapies Database. A deterministic-probabilistic linkage was performed using the Authorization System for High Complexity/Cost Procedures and the Mortality Information System databases. All patients who started dialysis between 1/1/2000 and 12/31/2004 were included and followed until death or the end of 2004. Age, sex, region of residence, primary renal disease and causes of death were analyzed. A proportional hazards model was used to identify factors associated with risk of death. RESULTS: The prevalence of patients under renal replacement therapies increased an average of 5.5%, while incidence remained stable during the period. Hemodialysis was the predominant initial modality (89%). The patients were majority male with mean age 53 years, residents of the Southeast region and presented unknown causes as the main cause of chronic renal disease, followed by hypertension, diabetes and glomerulonephritis. Of these patients, 42% progressed to death and 7% underwent kidney transplantation. The patients on peritoneal dialysis were older and had higher prevalence of diabetes. The death rate varied from 7% among transplanted patients to 45% among non-transplanted patients. In the final Cox proportional hazards model, the risk of mortality was associated with increasing age, female sex, having diabetes, living in the North and Northeast region, peritoneal dialysis as a first modality and not having renal transplantation. CONCLUSIONS: There was an increased prevalence of patients on renal therapy in Brazil. Increased risk of death was associated with advanced age, diabetes, the female sex, residents of the North and Northeast region and lack of renal transplant.",
+                        "a": "OBJECTIVE: To describe the clinical and epidemiological profile...",
                         "l": "en",
                         "_": ""
                     },
                     {
-                        "a": "OBJETIVO: Describir el perfil epidemiol\u00f3gico y cl\u00ednico de pacientes en terapia renal substitutiva, identificando factores asociados al riesgo de muerte. M\u00c9TODOS: Estudio de observaci\u00f3n, prospectivo no concurrente, a partir de datos de 90.356 pacientes de la Base Nacional en Terapias Renales Substitutivas, en Brasil. Fue realizado reracionamiento determin\u00edstico-probabil\u00edstico del Sistema de Informaci\u00f3n de Mortalidad. Fueron incluidos todos los pacientes incidentes que iniciaron di\u00e1lisis entre 1/1/2000 y 31/12/2004, acompa\u00f1ados hasta la muerte o final de 2004. Edad, sexo, regi\u00f3n de residencia, enfermedad renal primaria, causa del \u00f3bito fueron analizados. Se ajust\u00f3 un modelo de riesgos proporcionales para identificar factores asociados al riesgo de muerte. RESULTADOS: Ocurri\u00f3 un aumento promedio de 5,5% en la prevalencia de pacientes en terapia, con relaci\u00f3n a la incidencia se mantuvo estable en el per\u00edodo. Hemodi\u00e1lisis fue la modalidad inicial predominante (89%). La mayor\u00eda de los pacientes era del sexo masculino, con edad promedio de 53 a\u00f1os, residente en la regi\u00f3n Sureste y presentaba causa indeterminada como principal causa b\u00e1sica de la enfermedad renal cr\u00f3nica, seguida de la hipertensi\u00f3n, diabetes y glomerulonefritis. De esos pacientes, 7% realizaron transplante renal y 42% evolucionaron a \u00f3bito. Los pacientes en di\u00e1lisis peritoneal eran m\u00e1s ancianos y presentaban mayor prevalencia de diabetes. Entre los no transplantados, 45% fueron a \u00f3bito y, entre los transplantadas 7%. En el modelo final de riesgos proporcionales de Cox, el riesgo de mortalidad estuvo asociado con el aumento de la edad, sexo femenino, tener diabetes, residir en la regi\u00f3n Norte y Noreste, di\u00e1lisis peritoneal como modalidad de entrada y no haber realizado transplante renal. CONCLUSIONES: Hubo aumento de la prevalencia de pacientes en terapia renal en Brasil. Pacientes con edad avanzada, diabetes, del sexo femenino, residentes en la regi\u00f3n Norte y Noreste y sin transplante renal presentan mayor riesgo de muerte.",
+                        "a": "OBJETIVO: Describir el perfil epidemiol\u00f3gico y cl\u00ednico...",
                         "l": "es",
                         "_": ""
                     }
@@ -1234,9 +1234,17 @@ class ExportCrossRef_MultiLingueDoc_with_MultipleDOI_Tests(unittest.TestCase):
         xmlcrossref = export_crossref.XMLArticleAbstractPipe()
         raw, xml = xmlcrossref.transform(data)
 
-        abstracts = [raw.original_abstract()]
-        for body in raw.translated_abstracts().values():
-            abstracts.append(body)
+        expected_abstracts = [
+            "OBJETIVO: Descrever o perfil epidemiol\u00f3gico...",
+            "OBJECTIVE: To describe the clinical and epidemiological profile...",
+            "OBJETIVO: Describir el perfil epidemiol\u00f3gico y cl\u00ednico...",
+            "OBJECTIVE: To describe the clinical and epidemiological profile...",
+            "OBJETIVO: Descrever o perfil epidemiol\u00f3gico...",
+            "OBJETIVO: Describir el perfil epidemiol\u00f3gico y cl\u00ednico...",
+            "OBJETIVO: Describir el perfil epidemiol\u00f3gico y cl\u00ednico...",
+            "OBJETIVO: Descrever o perfil epidemiol\u00f3gico...",
+            "OBJECTIVE: To describe the clinical and epidemiological profile...",
+        ]
 
         abstract_nodes = xml.findall(
             './/{http://www.ncbi.nlm.nih.gov/JATS1}abstract/{http://www.ncbi.nlm.nih.gov/JATS1}p')
@@ -1244,7 +1252,8 @@ class ExportCrossRef_MultiLingueDoc_with_MultipleDOI_Tests(unittest.TestCase):
         self.assertEqual(9, len(abstract_nodes))
 
         xml_abstracts = [a.text for a in abstract_nodes]
-        self.assertEqual(abstracts * 3, xml_abstracts)
+        print(xml_abstracts)
+        self.assertListEqual(expected_abstracts, xml_abstracts)
 
     def test_related_item_for_multilingue_document(self):
         xmlcrossref = create_xmlcrossref_with_n_journal_article_element(
@@ -1487,17 +1496,17 @@ class ExportCrossRef_MultiLingueDoc_with_DOI_pt_es_Tests(unittest.TestCase):
                 ],
                 "v83": [
                     {
-                        "a": "OBJETIVO: Descrever o perfil epidemiol\u00f3gico e cl\u00ednico de pacientes em terapia renal substitutiva, identificando fatores associados ao risco de morte. M\u00c9TODOS: Estudo observacional, prospectivo n\u00e3o concorrente, a partir de dados de 90.356 pacientes da Base Nacional em Terapias Renais Substitutivas, no Brasil. Foi realizado relacionamento determin\u00edstico-probabil\u00edstico do Sistema de Autoriza\u00e7\u00e3o de Procedimentos de Alta Complexidade/Custo e do Sistema de Informa\u00e7\u00e3o de Mortalidade. Foram inclu\u00eddos todos os pacientes incidentes que iniciaram di\u00e1lise entre 1/1/2000 e 31/12/2004, acompanhados at\u00e9 a morte ou final de 2004. Idade, sexo, regi\u00e3o de resid\u00eancia, doen\u00e7a renal prim\u00e1ria, causa do \u00f3bito foram analisados. Ajustou-se um modelo de riscos proporcionais para identificar fatores associados ao risco de morte. RESULTADOS: Ocorreu um aumento m\u00e9dio de 5,5% na preval\u00eancia de pacientes em terapia enquanto a incid\u00eancia manteve-se est\u00e1vel no per\u00edodo. Hemodi\u00e1lise foi a modalidade inicial predominante (89%). A maioria dos pacientes era do sexo masculino, com idade m\u00e9dia de 53 anos, residente na regi\u00e3o Sudeste, e apresentava causa indeterminada como principal causa b\u00e1sica da doen\u00e7a renal cr\u00f4nica, seguida da hipertens\u00e3o, diabetes e glomerulonefrites. Desses pacientes, 7% realizou transplante renal e 42% evoluiu para o \u00f3bito. Os pacientes em di\u00e1lise peritoneal eram mais idosos e apresentavam maior preval\u00eancia de diabetes. Entre os n\u00e3o transplantados, 45% foi a \u00f3bito e, entre os transplantados, 7%. No modelo final de riscos proporcionais de Cox, o risco de mortalidade foi associado com o aumento da idade, sexo feminino, ter diabetes, residir nas regi\u00f5es Norte e Nordeste, di\u00e1lise peritoneal como modalidade de entrada e n\u00e3o ter realizado transplante renal. CONCLUS\u00d5ES: Houve aumento da preval\u00eancia de pacientes em terapia renal no Brasil. Pacientes com idade avan\u00e7ada, diabetes, do sexo feminino, residentes nas regi\u00f5es Norte e Nordeste e sem transplante renal apresentam maior risco de morte.",
+                        "a": "OBJETIVO: Descrever o perfil epidemiol\u00f3gico...",
                         "l": "pt",
                         "_": ""
                     },
                     {
-                        "a": "OBJECTIVE: To describe the clinical and epidemiological profile of patients under renal replacement therapies, identifying risk factors for death. METHODS: This is a non-concurrent cohort study of data for 90,356 patients in the National Renal Replacement Therapies Database. A deterministic-probabilistic linkage was performed using the Authorization System for High Complexity/Cost Procedures and the Mortality Information System databases. All patients who started dialysis between 1/1/2000 and 12/31/2004 were included and followed until death or the end of 2004. Age, sex, region of residence, primary renal disease and causes of death were analyzed. A proportional hazards model was used to identify factors associated with risk of death. RESULTS: The prevalence of patients under renal replacement therapies increased an average of 5.5%, while incidence remained stable during the period. Hemodialysis was the predominant initial modality (89%). The patients were majority male with mean age 53 years, residents of the Southeast region and presented unknown causes as the main cause of chronic renal disease, followed by hypertension, diabetes and glomerulonephritis. Of these patients, 42% progressed to death and 7% underwent kidney transplantation. The patients on peritoneal dialysis were older and had higher prevalence of diabetes. The death rate varied from 7% among transplanted patients to 45% among non-transplanted patients. In the final Cox proportional hazards model, the risk of mortality was associated with increasing age, female sex, having diabetes, living in the North and Northeast region, peritoneal dialysis as a first modality and not having renal transplantation. CONCLUSIONS: There was an increased prevalence of patients on renal therapy in Brazil. Increased risk of death was associated with advanced age, diabetes, the female sex, residents of the North and Northeast region and lack of renal transplant.",
+                        "a": "OBJECTIVE: To describe the clinical and epidemiological profile...",
                         "l": "en",
                         "_": ""
                     },
                     {
-                        "a": "OBJETIVO: Describir el perfil epidemiol\u00f3gico y cl\u00ednico de pacientes en terapia renal substitutiva, identificando factores asociados al riesgo de muerte. M\u00c9TODOS: Estudio de observaci\u00f3n, prospectivo no concurrente, a partir de datos de 90.356 pacientes de la Base Nacional en Terapias Renales Substitutivas, en Brasil. Fue realizado reracionamiento determin\u00edstico-probabil\u00edstico del Sistema de Informaci\u00f3n de Mortalidad. Fueron incluidos todos los pacientes incidentes que iniciaron di\u00e1lisis entre 1/1/2000 y 31/12/2004, acompa\u00f1ados hasta la muerte o final de 2004. Edad, sexo, regi\u00f3n de residencia, enfermedad renal primaria, causa del \u00f3bito fueron analizados. Se ajust\u00f3 un modelo de riesgos proporcionales para identificar factores asociados al riesgo de muerte. RESULTADOS: Ocurri\u00f3 un aumento promedio de 5,5% en la prevalencia de pacientes en terapia, con relaci\u00f3n a la incidencia se mantuvo estable en el per\u00edodo. Hemodi\u00e1lisis fue la modalidad inicial predominante (89%). La mayor\u00eda de los pacientes era del sexo masculino, con edad promedio de 53 a\u00f1os, residente en la regi\u00f3n Sureste y presentaba causa indeterminada como principal causa b\u00e1sica de la enfermedad renal cr\u00f3nica, seguida de la hipertensi\u00f3n, diabetes y glomerulonefritis. De esos pacientes, 7% realizaron transplante renal y 42% evolucionaron a \u00f3bito. Los pacientes en di\u00e1lisis peritoneal eran m\u00e1s ancianos y presentaban mayor prevalencia de diabetes. Entre los no transplantados, 45% fueron a \u00f3bito y, entre los transplantadas 7%. En el modelo final de riesgos proporcionales de Cox, el riesgo de mortalidad estuvo asociado con el aumento de la edad, sexo femenino, tener diabetes, residir en la regi\u00f3n Norte y Noreste, di\u00e1lisis peritoneal como modalidad de entrada y no haber realizado transplante renal. CONCLUSIONES: Hubo aumento de la prevalencia de pacientes en terapia renal en Brasil. Pacientes con edad avanzada, diabetes, del sexo femenino, residentes en la regi\u00f3n Norte y Noreste y sin transplante renal presentan mayor riesgo de muerte.",
+                        "a": "OBJETIVO: Describir el perfil epidemiol\u00f3gico y cl\u00ednico...",
                         "l": "es",
                         "_": ""
                     }
@@ -1774,9 +1783,14 @@ class ExportCrossRef_MultiLingueDoc_with_DOI_pt_es_Tests(unittest.TestCase):
         xmlcrossref = export_crossref.XMLArticleAbstractPipe()
         raw, xml = xmlcrossref.transform(data)
 
-        abstracts = [raw.original_abstract()]
-        for body in raw.translated_abstracts().values():
-            abstracts.append(body)
+        expected_abstracts = [
+            "OBJETIVO: Descrever o perfil epidemiol\u00f3gico...",
+            "OBJECTIVE: To describe the clinical and epidemiological profile...",
+            "OBJETIVO: Describir el perfil epidemiol\u00f3gico y cl\u00ednico...",
+            "OBJETIVO: Describir el perfil epidemiol\u00f3gico y cl\u00ednico...",
+            "OBJETIVO: Descrever o perfil epidemiol\u00f3gico...",
+            "OBJECTIVE: To describe the clinical and epidemiological profile...",
+        ]
 
         abstract_nodes = xml.findall(
             './/{http://www.ncbi.nlm.nih.gov/JATS1}abstract/{http://www.ncbi.nlm.nih.gov/JATS1}p')
@@ -1784,7 +1798,7 @@ class ExportCrossRef_MultiLingueDoc_with_DOI_pt_es_Tests(unittest.TestCase):
         self.assertEqual(6, len(abstract_nodes))
 
         xml_abstracts = [a.text for a in abstract_nodes]
-        self.assertEqual(abstracts * 2, xml_abstracts)
+        self.assertEqual(expected_abstracts, xml_abstracts)
 
     def test_related_item_for_multilingue_document(self):
         xmlcrossref = create_xmlcrossref_with_n_journal_article_element(

--- a/tests/test_export_crossref.py
+++ b/tests/test_export_crossref.py
@@ -1251,29 +1251,33 @@ class ExportCrossRef_MultiLingueDoc_with_MultipleDOI_Tests(unittest.TestCase):
             ['pt', 'en', 'es'])
 
         data = [self._article, xmlcrossref]
-        xmlcrossref = export_crossref.XMLProgramPipe()
+        xmlcrossref = export_crossref.XMLProgramRelatedItemPipe()
         raw, xml = xmlcrossref.transform(data)
 
         expected_content = [
             ('10.1590/ID.en',
              "Epidemiological profile of patients on"
              " renal replacement therapy in Brazil, 2000-2004",
-             0
+             0,
+             "isTranslationOf",
              ),
             ('10.1590/ID.es',
              "Perfil epidemiológico de los pacientes en terapia"
              " renal substitutiva en Brasil, 2000-2004",
-             1
+             1,
+             "isTranslationOf",
              ),
             ('10.1590/S0034-89102010000400007',
              "Perfil epidemiológico dos pacientes em terapia"
              " renal substitutiva no Brasil, 2000-2004",
-             2
+             2,
+             "hasTranslation",
              ),
             ('10.1590/S0034-89102010000400007',
              "Perfil epidemiológico dos pacientes em terapia"
              " renal substitutiva no Brasil, 2000-2004",
-             3
+             3,
+             "hasTranslation",
              ),
         ]
         self.assertEqual(
@@ -1294,7 +1298,7 @@ class ExportCrossRef_MultiLingueDoc_with_MultipleDOI_Tests(unittest.TestCase):
                 self.assertEqual(
                     'doi', intra_work_relation.attrib.get('identifier-type'))
                 self.assertEqual(
-                    'isTranslationOf',
+                    content[3],
                     intra_work_relation.attrib.get('relationship-type'))
 
     def test_collection_for_multilingue_document(self):
@@ -1787,24 +1791,21 @@ class ExportCrossRef_MultiLingueDoc_with_DOI_pt_es_Tests(unittest.TestCase):
             ['pt', 'es'])
 
         data = [self._article, xmlcrossref]
-        xmlcrossref = export_crossref.XMLProgramPipe()
+        xmlcrossref = export_crossref.XMLProgramRelatedItemPipe()
         raw, xml = xmlcrossref.transform(data)
 
         expected_content = [
             ('10.1590/ID.es',
              "Perfil epidemiológico de los pacientes en terapia"
              " renal substitutiva en Brasil, 2000-2004",
-             0
+             0,
+             "isTranslationOf",
              ),
             ('10.1590/S0034-89102010000400007',
              "Perfil epidemiológico dos pacientes em terapia"
              " renal substitutiva no Brasil, 2000-2004",
-             1
-             ),
-            ('10.1590/S0034-89102010000400007',
-             "Perfil epidemiológico dos pacientes em terapia"
-             " renal substitutiva no Brasil, 2000-2004",
-             2
+             1,
+             "hasTranslation",
              ),
         ]
         self.assertEqual(
@@ -1825,7 +1826,7 @@ class ExportCrossRef_MultiLingueDoc_with_DOI_pt_es_Tests(unittest.TestCase):
                 self.assertEqual(
                     'doi', intra_work_relation.attrib.get('identifier-type'))
                 self.assertEqual(
-                    'isTranslationOf',
+                    content[3],
                     intra_work_relation.attrib.get('relationship-type'))
 
     def test_collection_for_multilingue_document(self):


### PR DESCRIPTION
#### O que esse PR faz?
Fix absence of elements to identify has translation and is translation of

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
Executei os comandos a seguir no ipython

```python
import requests
doc = requests.get(
    "https://articlemeta.scielo.org/api/v1/article/?collection=scl&code=S0034-75902021000300300"
)

import json
data = json.loads(doc.text)

from articlemeta import export_crossref
from articlemeta.export import CustomArticle

xylose_article = CustomArticle(data)

import plumber
ppl = plumber.Pipeline(
            export_crossref.SetupDoiBatchPipe(),
            export_crossref.XMLHeadPipe(),
            export_crossref.XMLBodyPipe(),
            export_crossref.XMLDoiBatchIDPipe(),
            export_crossref.XMLTimeStampPipe(),
            export_crossref.XMLDepositorPipe(),
            export_crossref.XMLRegistrantPipe(),
            export_crossref.XMLJournalPipe(),
            export_crossref.XMLJournalMetadataPipe(),
            export_crossref.XMLJournalTitlePipe(),
            export_crossref.XMLAbbreviatedJournalTitlePipe(),
            export_crossref.XMLISSNPipe(),
            export_crossref.XMLJournalIssuePipe(),
            export_crossref.XMLPubDatePipe(),
            export_crossref.XMLVolumePipe(),
            export_crossref.XMLIssuePipe(),
            export_crossref.XMLJournalArticlePipe(),
            export_crossref.XMLArticleTitlesPipe(),
            export_crossref.XMLArticleTitlePipe(),
            export_crossref.XMLArticleContributorsPipe(),
            export_crossref.XMLArticleAbstractPipe(),
            export_crossref.XMLArticlePubDatePipe(),
            export_crossref.XMLPagesPipe(),
            export_crossref.XMLPIDPipe(),
            export_crossref.XMLElocationPipe(),
            export_crossref.XMLPermissionsPipe(),
            export_crossref.XMLProgramRelatedItemPipe(),
            export_crossref.XMLDOIDataPipe(),
            export_crossref.XMLDOIPipe(),
            export_crossref.XMLResourcePipe(),
            export_crossref.XMLCollectionPipe(),
            export_crossref.XMLArticleCitationsPipe(),
            export_crossref.XMLClosePipe()
        )
transformed_data = ppl.run(xylose_article, rewrap=True)
x = next(transformed_data)
with open("artigomultilingue.xml", "wb") as fp:
    fp.write(x)

```
Observe que no arquivo gerado contém as tags de relacionamento

[artigomultilingue.xml.zip](https://github.com/scieloorg/articles_meta/files/8325834/artigomultilingue.xml.zip)

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
<img width="1061" alt="Captura de Tela 2022-03-22 às 12 35 37" src="https://user-images.githubusercontent.com/505143/159521034-1fae6c66-d9ba-4d34-9b91-1de743e23f97.png">

<img width="1044" alt="Captura de Tela 2022-03-22 às 12 35 28" src="https://user-images.githubusercontent.com/505143/159521012-6a9af9f1-d0c5-46e7-9023-c9953909e6c2.png">

#### Quais são tickets relevantes?
n/a

### Referências
https://gitlab.com/crossref/schema/-/blob/master/best-practice-examples/journal_article_translation_4.8.0.xml
[journal_article_translation_4.8.0.xml.zip](https://github.com/scieloorg/articles_meta/files/8325779/journal_article_translation_4.8.0.xml.zip)

https://data.crossref.org/reports/help/schema_doc/5.3.1/index.html