### PR TITLE
Preenche o campo resource com o link para a versão do pdf correspondente

### DIFF
--- a/articlemeta/export_crossref.py
+++ b/articlemeta/export_crossref.py
@@ -764,12 +764,7 @@ class XMLResourcePipe(plumber.Pipe):
 
 class XMLCollectionPipe(plumber.Pipe):
 
-    def precond(data):
-
-        raw, xml = data
-
-        if not raw.fulltexts().get('pdf', None):
-            raise plumber.UnmetPrecondition()
+    ARTICLE_PDF = 'http://{}/scielo.php?script=sci_pdf&pid={}&tlng={}'
 
     def create_collection_element(self, resource_value):
         resource = ET.Element('resource')
@@ -784,15 +779,17 @@ class XMLCollectionPipe(plumber.Pipe):
         collection.append(item)
         return collection
 
-    @plumber.precondition(precond)
     def transform(self, data):
         raw, xml = data
-        pdf_items = raw.fulltexts().get('pdf')
+
         for doi_data, doi_and_lang in zip(
                 xml.findall('.//journal_article/doi_data'),
                 raw.doi_and_lang):
             collection = self.create_collection_element(
-                pdf_items.get(doi_and_lang[0]))
+                self.ARTICLE_PDF.format(
+                    raw.scielo_domain, raw.publisher_id, doi_and_lang[0]
+                )
+            )
             doi_data.append(collection)
 
         return data

--- a/tests/test_export_crossref.py
+++ b/tests/test_export_crossref.py
@@ -1336,9 +1336,9 @@ class ExportCrossRef_MultiLingueDoc_with_MultipleDOI_Tests(unittest.TestCase):
         raw, xml = xmlcrossref.transform(data)
 
         texts = [
-            "http://www.scielo.br/pdf/rsp/v44n4/07.pdf",
-            "http://www.scielo.br/pdf/rsp/v44n4/en_07.pdf",
-            "http://www.scielo.br/pdf/rsp/v44n4/es_07.pdf",
+            "http://www.scielo.br/scielo.php?script=sci_pdf&pid=S0034-89102010000400007&tlng=pt",
+            "http://www.scielo.br/scielo.php?script=sci_pdf&pid=S0034-89102010000400007&tlng=en",
+            "http://www.scielo.br/scielo.php?script=sci_pdf&pid=S0034-89102010000400007&tlng=es",
         ]
         self.assertEqual(
             3, len(xml.findall('.//doi_data//collection')))
@@ -1875,9 +1875,10 @@ class ExportCrossRef_MultiLingueDoc_with_DOI_pt_es_Tests(unittest.TestCase):
         raw, xml = xmlcrossref.transform(data)
 
         texts = [
-            "http://www.scielo.br/pdf/rsp/v44n4/07.pdf",
-            "http://www.scielo.br/pdf/rsp/v44n4/es_07.pdf",
+            "http://www.scielo.br/scielo.php?script=sci_pdf&pid=S0034-89102010000400007&tlng=pt",
+            "http://www.scielo.br/scielo.php?script=sci_pdf&pid=S0034-89102010000400007&tlng=es",
         ]
+
         self.assertEqual(
             2, len(xml.findall('.//doi_data//collection')))
         for res, text in zip(


### PR DESCRIPTION
#### O que esse PR faz?
Remove a dependência da existência do dado `document["fulltexts"]["pdfs"]` gerado a partir do processamento `load_languages`

No lugar do path dos pdfs, coloca o link da página do pdf: `http://www.scielo.br?script=sci_arttext&pid=<pid>&tlng=<lang>`

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
Execute no ipython

```python
import requests
doc = requests.get(
    "https://articlemeta.scielo.org/api/v1/article/?collection=scl&code=S0034-75902021000300300"
)

import json
data = json.loads(doc.text)

from articlemeta import export_crossref
from articlemeta.export import CustomArticle

xylose_article = CustomArticle(data)

import plumber
ppl = plumber.Pipeline(
            export_crossref.SetupDoiBatchPipe(),
            export_crossref.XMLHeadPipe(),
            export_crossref.XMLBodyPipe(),
            export_crossref.XMLDoiBatchIDPipe(),
            export_crossref.XMLTimeStampPipe(),
            export_crossref.XMLDepositorPipe(),
            export_crossref.XMLRegistrantPipe(),
            export_crossref.XMLJournalPipe(),
            export_crossref.XMLJournalMetadataPipe(),
            export_crossref.XMLJournalTitlePipe(),
            export_crossref.XMLAbbreviatedJournalTitlePipe(),
            export_crossref.XMLISSNPipe(),
            export_crossref.XMLJournalIssuePipe(),
            export_crossref.XMLPubDatePipe(),
            export_crossref.XMLVolumePipe(),
            export_crossref.XMLIssuePipe(),
            export_crossref.XMLJournalArticlePipe(),
            export_crossref.XMLArticleTitlesPipe(),
            export_crossref.XMLArticleTitlePipe(),
            export_crossref.XMLArticleContributorsPipe(),
            export_crossref.XMLArticleAbstractPipe(),
            export_crossref.XMLArticlePubDatePipe(),
            export_crossref.XMLPagesPipe(),
            export_crossref.XMLPIDPipe(),
            export_crossref.XMLElocationPipe(),
            export_crossref.XMLPermissionsPipe(),
            export_crossref.XMLProgramRelatedItemPipe(),
            export_crossref.XMLDOIDataPipe(),
            export_crossref.XMLDOIPipe(),
            export_crossref.XMLResourcePipe(),
            export_crossref.XMLCollectionPipe(),
            export_crossref.XMLArticleCitationsPipe(),
            export_crossref.XMLClosePipe()
        )
transformed_data = ppl.run(xylose_article, rewrap=True)
x = next(transformed_data)
with open("artigomultilingue.xml", "wb") as fp:
    fp.write(x)
```
#### Algum cenário de contexto que queira dar?
N/A

### Screenshots
N/A

#### Quais são tickets relevantes?
https://github.com/scieloorg/doi_request/issues/28

### Referências
N/A