### PR TITLE
Corrige bug causado por não considerar "ausência de títulos traduzidos"

### DIFF
--- a/articlemeta/export_crossref.py
+++ b/articlemeta/export_crossref.py
@@ -351,7 +351,8 @@ def title_doi_lang(raw):
 
 
 def _get_langs_ordered_by_priority(raw):
-    article_langs = [raw.original_language()] + list(raw.translated_titles().keys())
+    other_langs = list((raw.translated_titles() or {}).keys())
+    article_langs = [raw.original_language()] + other_langs
     main_langs = []
     for lang in ["en", "pt", "es"] + article_langs:
         if lang in article_langs and lang not in main_langs:
@@ -372,7 +373,7 @@ class XMLArticleTitlePipe(plumber.Pipe):
         nodes = xml.findall('.//journal_article')
 
         article_titles = {raw.original_language(): raw.original_title()}
-        article_titles.update(raw.translated_titles())
+        article_titles.update(raw.translated_titles() or {})
         langs_ordered_by_priority = _get_langs_ordered_by_priority(raw)
 
         for ja in nodes:
@@ -1141,7 +1142,7 @@ class XMLProgramRelatedItemPipe(plumber.Pipe):
         program_node.set('xmlns',  'http://www.crossref.org/relations.xsd')
 
         original_language = raw.original_language()
-        translated_titles = raw.translated_titles()
+        translated_titles = raw.translated_titles() or {}
         for lang, doi in raw.doi_and_lang:
             if lang == original_language:
                 continue

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ test_requires = ['mocker', 'nose>=1.0', 'coverage', 'mongomock']
 
 setup(
     name="articlemeta",
-    version='1.45.21',
+    version='1.45.22',
     description="A SciELO API to load SciELO Articles metadata",
     author="SciELO",
     author_email="scielo-dev@googlegroups.com",

--- a/tests/test_export_crossref.py
+++ b/tests/test_export_crossref.py
@@ -1673,6 +1673,32 @@ class ExportCrossRef_MultiLingueDoc_with_DOI_pt_es_Tests(unittest.TestCase):
         self.assertEqual(expected_titles, titles)
         self.assertEqual(expected_alt_titles, alt_titles)
 
+    def test_article_title_element_once(self):
+        xmlcrossref = create_xmlcrossref_with_n_journal_article_element(
+            ['pt'], 'titles')
+
+        self._article.data["article"]["v12"] = [
+            {
+                "l": "pt",
+                "_": "Perfil epidemiológico dos pacientes em terapia"
+                " renal substitutiva no Brasil, 2000-2004"
+            },
+        ]
+        data = [self._article, xmlcrossref]
+
+        xmlcrossref = export_crossref.XMLArticleTitlePipe()
+        raw, xml = xmlcrossref.transform(data)
+
+        expected_titles = [
+            'Perfil epidemiológico dos pacientes em terapia renal substitutiva no Brasil, 2000-2004',
+        ]
+        expected_alt_titles = []
+        titles = [node.text for node in xml.findall(".//journal_article//title")]
+        alt_titles = [node.text for node in xml.findall(".//journal_article//original_language_title")]
+
+        self.assertEqual(expected_titles, titles)
+        self.assertEqual(expected_alt_titles, alt_titles)
+
     def test_article_contributors_element(self):
         xmlcrossref = create_xmlcrossref_with_n_journal_article_element(
             ['pt', 'es'])


### PR DESCRIPTION
#### O que esse PR faz?
Corrige bug causado por não considerar "ausência de títulos traduzidos"

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?

```python
import requests
doc = requests.get(
    "https://articlemeta.scielo.org/api/v1/article/?collection=scl&code=S0102-86502022000100206"
)

import json
data = json.loads(doc.text)

from articlemeta import export_crossref
from articlemeta.export import CustomArticle

xylose_article = CustomArticle(data)

import plumber
ppl = plumber.Pipeline(
            export_crossref.SetupDoiBatchPipe(),
            export_crossref.XMLHeadPipe(),
            export_crossref.XMLBodyPipe(),
            export_crossref.XMLDoiBatchIDPipe(),
            export_crossref.XMLTimeStampPipe(),
            export_crossref.XMLDepositorPipe(),
            export_crossref.XMLRegistrantPipe(),
            export_crossref.XMLJournalPipe(),
            export_crossref.XMLJournalMetadataPipe(),
            export_crossref.XMLJournalTitlePipe(),
            export_crossref.XMLAbbreviatedJournalTitlePipe(),
            export_crossref.XMLISSNPipe(),
            export_crossref.XMLJournalIssuePipe(),
            export_crossref.XMLPubDatePipe(),
            export_crossref.XMLVolumePipe(),
            export_crossref.XMLIssuePipe(),
            export_crossref.XMLJournalArticlePipe(),
            export_crossref.XMLArticleTitlesPipe(),
            export_crossref.XMLArticleTitlePipe(),
            export_crossref.XMLArticleContributorsPipe(),
            export_crossref.XMLArticleAbstractPipe(),
            export_crossref.XMLArticlePubDatePipe(),
            export_crossref.XMLPagesPipe(),
            export_crossref.XMLPIDPipe(),
            export_crossref.XMLElocationPipe(),
            export_crossref.XMLPermissionsPipe(),
            export_crossref.XMLProgramRelatedItemPipe(),
            export_crossref.XMLDOIDataPipe(),
            export_crossref.XMLDOIPipe(),
            export_crossref.XMLResourcePipe(),
            export_crossref.XMLCollectionPipe(),
            export_crossref.XMLArticleCitationsPipe(),
            export_crossref.XMLClosePipe()
        )
transformed_data = ppl.run(xylose_article, rewrap=True)
x = next(transformed_data)
with open("artigomultilingue.xml", "wb") as fp:
    fp.write(x)
````

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
#234 

### Referências
n/a
