### PR TITLE
Corrige Dockerfile-dev e dependência WebOb para o ambiente de desenvolvimento

### DIFF
--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -4,12 +4,21 @@ MAINTAINER tecnologia@scielo.org
 
 COPY . /app
 COPY development.ini-TEMPLATE /app/config.ini
+COPY requirements.txt . 
 
 WORKDIR /app
 
-RUN pip install --upgrade pip
-RUN pip install gunicorn
+RUN apk update && apk add --no-cache \
+  build-base \
+  git
+
+RUN pip install --upgrade pip \
+    && pip install --no-cache-dir -r requirements.txt \
+    && pip install pyramid_debugtoolbar \
+    %% pip install waitress 
 
 ENV ARTICLEMETA_SETTINGS_FILE=/app/config.ini
 
 RUN python setup.py develop
+
+CMD ["pserve", "/app/config.ini"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ thriftpy2==0.5.0
 -e git+https://github.com/scieloorg/thriftpy2-wrap@1.0.0#egg=thriftpywrap
 urllib3==1.26.19
 venusian==1.1.0
-WebOb==1.8.0rc1
+WebOb==1.8.7
 -e git+https://github.com/scieloorg/xylose.git@1.35.9#egg=xylose
 zope.deprecation==4.3.0
 zope.interface==6.1


### PR DESCRIPTION
#### O que esse PR faz?
Corrige Dockerfile-dev e dependência WebOb para o ambiente de desenvolvimento

#### Onde a revisão poderia começar?
pelos commits

#### Como este poderia ser testado manualmente?
1. docker build -f Dockerfile-dev -t article_meta_dev:latest .
2. docker run --name my-articlemeta -d article_meta_dev
Para desenvolvimento e testes do build do projeto, é possível simular uma conexão com o MongoDB da seguinte forma:

Originalmente, a conexão com o MongoDB é feita assim:

```python
    db_url = urlparse(db_dsn)
    conn = pymongo.MongoClient('mongodb://%s' % db_url.netloc)
    db = conn[db_url.path[1:]]
    _create_indexes(db)
    return db
```
Para simular (fakear) a conexão com o MongoDB, você pode usar a biblioteca mongomock desta maneira:
```python
    db_url = urlparse(db_dsn)
    import mongomock
    conn = mongomock.MongoClient('mongodb://localhost')
    db = conn[db_url.path[1:]]
    _create_indexes(db)
    return db
```
#### Algum cenário de contexto que queira dar?
N/A

### Screenshots
![image](https://github.com/scieloorg/articles_meta/assets/82840278/8236d919-fb88-415c-bf31-75705bca54e3)


#### Quais são tickets relevantes?
#261 

### Referências
n/a
