### PR TITLE
Adiciona o ``orcid`` no contrib group para o formato xmlwos.

### DIFF
--- a/articlemeta/export_sci.py
+++ b/articlemeta/export_sci.py
@@ -725,6 +725,14 @@ class XMLArticleMetaContribGroupPipe(plumber.Pipe):
             if author.get("role", "ND") != "ND":
                 contrib_type = author.get("role")
             contrib.set('contrib-type', contrib_type)
+
+            # <contrib-id contrib-id-type="orcid">0000-0003-1447-4613</contrib-id>
+            if author.get("orcid"):
+                contrib_id = ET.Element("contrib-id")
+                contrib_id.set("contrib-id-type", "orcid")
+                contrib_id.text = author['orcid']
+                contrib.append(contrib_id)
+                
             contrib.append(contribname)
 
             for xr in author.get('xref', []):


### PR DESCRIPTION
#### O que esse PR faz?
Adiciona o ``orcid`` no contrib group para o formato xmlwos.

#### Onde a revisão poderia começar?

Por commit.

#### Como este poderia ser testado manualmente?

Acessando a URL:http://localhost:8000/api/v1/article/?code=S1808-24322023000100234&format=xmlrsps

#### Algum cenário de contexto que queira dar?
N/A

### Screenshots

![Screenshot 2024-07-26 at 12 20 02](https://github.com/user-attachments/assets/a70dc331-bc53-4fb5-82c2-0efa99f77fe5)


#### Quais são tickets relevantes?
Não há tíquete para essa atividade.

### Referências
N/A
