### PR TITLE
Verifica a existência de resumo traduzido na classe XMLArticleAbstracttPipe;

### DIFF
--- a/articlemeta/export_crossref.py
+++ b/articlemeta/export_crossref.py
@@ -505,7 +505,7 @@ class XMLArticleAbstractPipe(plumber.Pipe):
 
         raw, xml = data
 
-        if not raw.original_abstract() or not raw.translated_abstracts():
+        if not raw.original_abstract():
             raise plumber.UnmetPrecondition()
 
     @plumber.precondition(precond)

--- a/articlemeta/export_crossref.py
+++ b/articlemeta/export_crossref.py
@@ -519,13 +519,14 @@ class XMLArticleAbstractPipe(plumber.Pipe):
         abstract.append(paragraph)
         abstracts = {raw.original_language(): abstract}
 
-        for language, body in raw.translated_abstracts().items():
-            paragraph = ET.Element('{http://www.ncbi.nlm.nih.gov/JATS1}p')
-            paragraph.text = body
-            abstract = ET.Element('{http://www.ncbi.nlm.nih.gov/JATS1}abstract')
-            abstract.set('{http://www.w3.org/XML/1998/namespace}lang', language)
-            abstract.append(paragraph)
-            abstracts[language] = abstract
+        if raw.translated_abstracts():
+            for language, body in raw.translated_abstracts().items():
+                paragraph = ET.Element('{http://www.ncbi.nlm.nih.gov/JATS1}p')
+                paragraph.text = body
+                abstract = ET.Element('{http://www.ncbi.nlm.nih.gov/JATS1}abstract')
+                abstract.set('{http://www.w3.org/XML/1998/namespace}lang', language)
+                abstract.append(paragraph)
+                abstracts[language] = abstract
 
         for journal_article in xml.findall('./body/journal//journal_article'):
             language = journal_article.get("language")


### PR DESCRIPTION
#### O que esse PR faz?
Verifica a existência de resumo traduzido na classe XMLArticleAbstracttPipe;

#### Onde a revisão poderia começar?
pelos commits

#### Como este poderia ser testado manualmente?
```python
import json
import requests
from articlemeta.export_crossref import XMLArticleAbstractPipe
from articlemeta.export import CustomArticle as Article
from tests.test_export_crossref import create_xmlcrossref_with_n_journal_article_element
response = requests.get("https://articlemeta.scielo.org/api/v1/article/?code=S2175-91462024000100401")
content  = json.loads(response.content)
article = Article(content)
xmlcrossref = create_xmlcrossref_with_n_journal_article_element(['en'])
data = [article, xmlcrossref]
raw, xml = XMLArticleAbstractPipe().transform(data)
from lxml import etree as ET
ET.tostring(xml)
```

#### Algum cenário de contexto que queira dar?
N/A

### Screenshots
N/A

#### Quais são tickets relevantes?
#283 

### Referências
N/A
