### PR TITLE
fix: corrige extração de nomes de patrocinadores no método `append_funding_data`

### DIFF
--- a/articlemeta/export_crossref.py
+++ b/articlemeta/export_crossref.py
@@ -1233,7 +1233,8 @@ class XMLFundingDataPipe(plumber.Pipe):
                 foundgroup.append(self.create_assertion(name="award_number", text=contract))
                 program.append(foundgroup)
         elif sponsors:
-            for sponsor in sponsors:
+            sponsors_name = [i.get("orgname") for i in sponsors if i.get("orgname")]
+            for sponsor in sponsors_name:
                 foundgroup = self.create_fundgroup()
                 foundgroup.append(self.create_assertion(name="funder_name", text=sponsor))
                 program.append(foundgroup)


### PR DESCRIPTION
#### O que esse PR faz?
fix: corrige extração de nomes de patrocinadores no método `append_funding_data`

#### Onde a revisão poderia começar?
pelos commits

#### Como este poderia ser testado manualmente?
ipython
```python
import json
import requests
from articlemeta.export_crossref import XMLFundingDataPipe
from articlemeta.export import CustomArticle as Article
from tests.test_export_crossref import create_xmlcrossref_with_n_journal_article_element
response = requests.get("https://articlemeta.scielo.org/api/v1/article/?code=S0102-86502024000100201")
content  = json.loads(response.content)
article = Article(content)
xmlcrossref = create_xmlcrossref_with_n_journal_article_element(['pt', 'en', 'es'])
data = [article, xmlcrossref]
raw, xml = XMLFundingDataPipe().transform(data)
from lxml import etree as ET
ET.tostring(xml)
```

#### Algum cenário de contexto que queira dar?
N/A

### Screenshots
N/A

#### Quais são tickets relevantes?
#286 

### Referências
N/A
