### PR TITLE
Adiciona validação e extração de URLs válidas em URIPipe

### DIFF
--- a/tests/test_export_sci.py
+++ b/tests/test_export_sci.py
@@ -100,6 +100,23 @@ class XMLCitationTests(unittest.TestCase):
         expected = xml.find('./element-citation/ext-link').text
 
         self.assertEqual(u'http://www.scielo.br', expected)
+    
+    def test_xml_citation_with_broken_url_pipe(self):
+
+        fakexylosearticle = Article({'article': {},
+                                     'title': {},
+                                     'citations': [{'v37': [{'_': 'http:// http://www.scielo.br'}]}]}).citations[0]
+
+        pxml = ET.Element('ref')
+        pxml.append(ET.Element('element-citation'))
+
+        data = [fakexylosearticle, pxml]
+
+        raw, xml = self._xmlcitation.URIPipe().transform(data)
+
+        expected = xml.find('./element-citation/ext-link').text
+
+        self.assertEqual(u'http://www.scielo.br', expected)
 
     def test_xml_citation_persongrouppipe_create_author_collab(self):
         node = self._xmlcitation.PersonGroupPipe()._create_author(


### PR DESCRIPTION
#### O que esse PR faz?
Adiciona validação e extração de URLs válidas em URIPipe.

#### Onde a revisão poderia começar?
pelos commits

#### Como este poderia ser testado manualmente?
```python python3 -m unittest article_meta.tests.XMLCitationTests.test_xml_citation_with_broken_url_pipe```

#### Algum cenário de contexto que queira dar?
N/A

### Screenshots
N/A

#### Quais são tickets relevantes?
#293 

### Referências
N/A
