### PR TITLE
Adiciona related_item para os relacionamentos hasReview, isCommentOn, isReplyTo, isReviewOf, hasPreprint, etc

### DIFF
--- a/articlemeta/export_crossref.py
+++ b/articlemeta/export_crossref.py
@@ -1,14 +1,14 @@
 # coding: utf-8
-from lxml import etree as ET
-import re
 import os
+import re
 import uuid
 from copy import deepcopy
 from datetime import datetime
 from itertools import product
 
-from xylose.scielodocument import UnavailableMetadataException
 import plumber
+from lxml import etree as ET
+from xylose.scielodocument import UnavailableMetadataException
 
 SUPPLBEG_REGEX = re.compile(r'^0 ')
 SUPPLEND_REGEX = re.compile(r' 0$')
@@ -204,7 +204,7 @@ class XMLJournalIssuePipe(plumber.Pipe):
         try:
             if raw.issue.is_ahead_of_print:
                 raise plumber.UnmetPrecondition()
-        except UnavailableMetadataException as e:
+        except UnavailableMetadataException:
             raise plumber.UnmetPrecondition()
 
     @plumber.precondition(precond)
@@ -1127,22 +1127,77 @@ class XMLClosePipe(plumber.Pipe):
 
 
 class XMLProgramRelatedItemPipe(plumber.Pipe):
+    RELATIONS_NAMESPACE = 'http://www.crossref.org/relations.xsd'
+    RELATION_TYPES = {
+        'commentary-article': ('inter_work_relation', 'isCommentOn'),
+        'reply': ('inter_work_relation', 'isReplyTo'),
+        'reviewed-article': ('inter_work_relation', 'isReviewOf'),
+        'reviewer-report': ('inter_work_relation', 'hasReview'),
+        'preprint': ('intra_work_relation', 'hasPreprint'),
+        'article-commentary': ('inter_work_relation', 'isCommentOn'),
+        'letter': ('inter_work_relation', 'isReplyTo'),
+        'book-review': ('inter_work_relation', 'isReviewOf'),
+        'editorial': ('inter_work_relation', 'isCommentOn'),
+    }
+    DEFAULT_DESCRIPTIONS = {
+        'commentary-article': 'Documento comentado',
+        'reply': 'Documento respondido',
+        'reviewed-article': 'Documento revisado por pares',
+        'reviewer-report': 'Documento com parecer (revisão por pares)',
+        'preprint': 'Preprint relacionado ao artigo',
+        'article-commentary': 'Documento comentado',
+        'letter': 'Documento respondido',
+        'book-review': 'Documento resenhado',
+        'editorial': 'Documento editorial relacionado',
+    }
 
     def transform(self, data):
         raw, xml = data
         data = self._transform_original(data)
+        data = self._transform_related_articles(data)
         data = self._transform_translations(data)
         return data
+
+    @classmethod
+    def _create_program(cls):
+        program_node = ET.Element('program')
+        program_node.set('xmlns', cls.RELATIONS_NAMESPACE)
+        return program_node
+
+    @classmethod
+    def _get_or_create_program(cls, journal_article_node):
+        program_node = journal_article_node.find('program')
+        if program_node is None:
+            program_node = cls._create_program()
+            journal_article_node.append(program_node)
+        return program_node
+
+    @staticmethod
+    def _create_related_item(
+            description,
+            relation_element,
+            relationship_type,
+            identifier,
+            identifier_type='doi'):
+        related_item_node = ET.Element('related_item')
+
+        description_node = ET.Element('description')
+        description_node.text = description
+        related_item_node.append(description_node)
+
+        relation_node = ET.Element(relation_element)
+        relation_node.set('relationship-type', relationship_type)
+        relation_node.set('identifier-type', identifier_type)
+        relation_node.text = identifier
+        related_item_node.append(relation_node)
+
+        return related_item_node
 
     def _transform_original(self, data):
         raw, xml = data
 
-        # first journal_article (main)
         journal_article_node = xml.find('.//journal_article')
-
-        # program
-        program_node = ET.Element("program")
-        program_node.set('xmlns',  'http://www.crossref.org/relations.xsd')
+        program_node = self._get_or_create_program(journal_article_node)
 
         original_language = raw.original_language()
         translated_titles = raw.translated_titles() or {}
@@ -1150,57 +1205,62 @@ class XMLProgramRelatedItemPipe(plumber.Pipe):
             if lang == original_language:
                 continue
 
-            # program/related_item
-            related_item_node = ET.Element('related_item')
-
-            # program/related_item/description
-            description_node = ET.Element('description')
-            description_node.text = translated_titles.get(lang)
-            related_item_node.append(description_node)
-
-            # program/related_item/intra_work_relation
-            intra_work_relation_node = ET.Element('intra_work_relation')
-            intra_work_relation_node.set(
-                'relationship-type', 'isTranslationOf')
-            intra_work_relation_node.set('identifier-type', 'doi')
-            intra_work_relation_node.text = doi
-            related_item_node.append(intra_work_relation_node)
-
-            program_node.append(related_item_node)
-
-        journal_article_node.append(program_node)
+            program_node.append(self._create_related_item(
+                translated_titles.get(lang),
+                'intra_work_relation',
+                'isTranslationOf',
+                doi,
+            ))
 
         return data
 
     def _transform_translations(self, data):
         raw, xml = data
 
-        # program
-        program_node = ET.Element("program")
-        program_node.set('xmlns',  'http://www.crossref.org/relations.xsd')
-
-        # program/related_item
-        related_item_node = ET.Element('related_item')
-
-        # program/related_item/description
-        description_node = ET.Element('description')
-        description_node.text = raw.original_title()
-        related_item_node.append(description_node)
-
-        # program/related_item/intra_work_relation
-        intra_work_relation_node = ET.Element('intra_work_relation')
-        intra_work_relation_node.set(
-            'relationship-type', 'hasTranslation')
-        intra_work_relation_node.set('identifier-type', 'doi')
-        intra_work_relation_node.text = raw.doi
-        related_item_node.append(intra_work_relation_node)
-
-        program_node.append(related_item_node)
-
         for journal_article_node in xml.findall('.//journal_article')[1:]:
-            journal_article_node.append(deepcopy(program_node))
+            program_node = self._create_program()
+            program_node.append(self._create_related_item(
+                raw.original_title(),
+                'intra_work_relation',
+                'hasTranslation',
+                raw.doi,
+            ))
+            journal_article_node.append(program_node)
 
         return data
+
+    def _transform_related_articles(self, data):
+        raw, xml = data
+        related_articles = getattr(raw, 'related_documents', None)
+        if callable(related_articles):
+            related_articles = related_articles()
+
+        if not related_articles:
+            return data
+
+        journal_article_node = xml.find('.//journal_article')
+        program_node = self._get_or_create_program(journal_article_node)
+
+        for related_article in related_articles:
+            document_type = related_article.get('document_type')
+            if not document_type:
+                document_type = getattr(raw, 'document_type', None)
+            relation_data = self.RELATION_TYPES.get(document_type)
+            identifier = related_article.get('identifier')
+            if not relation_data or not identifier:
+                continue
+
+            program_node.append(self._create_related_item(
+                self.DEFAULT_DESCRIPTIONS.get(
+                    document_type, ''),
+                relation_data[0],
+                relation_data[1],
+                identifier,
+                related_article.get('identifier_type') or 'doi',
+            ))
+
+        return data
+
 
 class XMLFundingDataPipe(plumber.Pipe):
     def precond(data):
@@ -1213,7 +1273,7 @@ class XMLFundingDataPipe(plumber.Pipe):
         element = ET.Element("{http://www.crossref.org/fundref.xsd}assertion")
         element.set("name", name)
         element.text = text
-        
+
         return element
 
     @staticmethod
@@ -1247,12 +1307,12 @@ class XMLFundingDataPipe(plumber.Pipe):
     @plumber.precondition(precond)
     def transform(self, data):
         raw, xml = data
-        
+
         program = ET.Element(
             "{http://www.crossref.org/fundref.xsd}program"
         )
         program.set("name", "fundref")
-        
+
         self.append_funding_data(
             program=program,
             sponsors=raw.project_sponsor,

--- a/articlemeta/export_crossref.py
+++ b/articlemeta/export_crossref.py
@@ -1139,17 +1139,6 @@ class XMLProgramRelatedItemPipe(plumber.Pipe):
         'book-review': ('inter_work_relation', 'isReviewOf'),
         'editorial': ('inter_work_relation', 'isCommentOn'),
     }
-    DEFAULT_DESCRIPTIONS = {
-        'commentary-article': 'Documento comentado',
-        'reply': 'Documento respondido',
-        'reviewed-article': 'Documento revisado por pares',
-        'reviewer-report': 'Documento com parecer (revisão por pares)',
-        'preprint': 'Preprint relacionado ao artigo',
-        'article-commentary': 'Documento comentado',
-        'letter': 'Documento respondido',
-        'book-review': 'Documento resenhado',
-        'editorial': 'Documento editorial relacionado',
-    }
 
     def transform(self, data):
         raw, xml = data
@@ -1174,16 +1163,17 @@ class XMLProgramRelatedItemPipe(plumber.Pipe):
 
     @staticmethod
     def _create_related_item(
-            description,
             relation_element,
             relationship_type,
             identifier,
-            identifier_type='doi'):
+            identifier_type='doi',
+            description=None):
         related_item_node = ET.Element('related_item')
 
-        description_node = ET.Element('description')
-        description_node.text = description
-        related_item_node.append(description_node)
+        if description is not None:
+            description_node = ET.Element('description')
+            description_node.text = description
+            related_item_node.append(description_node)
 
         relation_node = ET.Element(relation_element)
         relation_node.set('relationship-type', relationship_type)
@@ -1206,10 +1196,10 @@ class XMLProgramRelatedItemPipe(plumber.Pipe):
                 continue
 
             program_node.append(self._create_related_item(
-                translated_titles.get(lang),
                 'intra_work_relation',
                 'isTranslationOf',
                 doi,
+                description=translated_titles.get(lang),
             ))
 
         return data
@@ -1220,10 +1210,10 @@ class XMLProgramRelatedItemPipe(plumber.Pipe):
         for journal_article_node in xml.findall('.//journal_article')[1:]:
             program_node = self._create_program()
             program_node.append(self._create_related_item(
-                raw.original_title(),
                 'intra_work_relation',
                 'hasTranslation',
                 raw.doi,
+                description=raw.original_title(),
             ))
             journal_article_node.append(program_node)
 
@@ -1251,8 +1241,6 @@ class XMLProgramRelatedItemPipe(plumber.Pipe):
                 continue
 
             program_node.append(self._create_related_item(
-                self.DEFAULT_DESCRIPTIONS.get(
-                    document_type, ''),
                 relation_data[0],
                 relation_data[1],
                 identifier,

--- a/articlemeta/export_crossref.py
+++ b/articlemeta/export_crossref.py
@@ -1135,10 +1135,9 @@ class XMLProgramRelatedItemPipe(plumber.Pipe):
     #
     # Os valores "commentary" e "letter" se repetem na especificação SciELO e
     # são desambiguados pelo `document_type` do documento CORRENTE (valores de
-    # choices.article_types do xylose):
-    #   - article-commentary → isCommentOn
-    #   - research-article   → hasComment (apenas para "commentary")
-    #   - demais             → isReplyTo (chave ``None``)
+    # choices.article_types do xylose, além de "reply" quando aplicável).
+    # Somente combinações conhecidas/documentadas são emitidas; demais
+    # combinações são ignoradas até haver casos reais.
     # Tipos ausentes deste dicionário não geram related_item.
     RELATED_ARTICLE_TYPE_RELATIONS = {
         'commentary-article': ('inter_work_relation', 'isCommentOn'),
@@ -1150,11 +1149,11 @@ class XMLProgramRelatedItemPipe(plumber.Pipe):
         'commentary': {
             'article-commentary': ('inter_work_relation', 'isCommentOn'),
             'research-article': ('inter_work_relation', 'hasComment'),
-            None: ('inter_work_relation', 'isReplyTo'),
+            'reply': ('inter_work_relation', 'isReplyTo'),
         },
         'letter': {
             'article-commentary': ('inter_work_relation', 'isCommentOn'),
-            None: ('inter_work_relation', 'isReplyTo'),
+            'reply': ('inter_work_relation', 'isReplyTo'),
         },
         'article-commentary': ('inter_work_relation', 'isCommentOn'),
     }
@@ -1167,7 +1166,7 @@ class XMLProgramRelatedItemPipe(plumber.Pipe):
         Usa o `related-article-type` do documento relacionado como fonte
         primária e o `current_document_type` do documento corrente para desambiguar
         os valores que se repetem na especificação SciELO (ex.: "letter" e
-        "commentary").
+        "commentary"). Combinações não mapeadas retornam ``None``.
         """
         related_article_type = related_article.get('related_article_type')
         if not related_article_type:
@@ -1178,8 +1177,7 @@ class XMLProgramRelatedItemPipe(plumber.Pipe):
             return None
 
         if isinstance(relation, dict):
-            relation = relation.get(
-                current_document_type, relation.get(None))
+            return relation.get(current_document_type)
 
         return relation
 
@@ -1230,13 +1228,15 @@ class XMLProgramRelatedItemPipe(plumber.Pipe):
         raw, xml = data
 
         journal_article_node = xml.find('.//journal_article')
-        program_node = self._get_or_create_program(journal_article_node)
 
         original_language = raw.original_language()
         translated_titles = raw.translated_titles() or {}
+        program_node = None
         for lang, doi in raw.doi_and_lang:
             if lang == original_language:
                 continue
+
+            program_node = self._get_or_create_program(journal_article_node)
 
             program_node.append(self._create_related_item(
                 'intra_work_relation',

--- a/articlemeta/export_crossref.py
+++ b/articlemeta/export_crossref.py
@@ -748,7 +748,7 @@ class XMLResourcePipe(plumber.Pipe):
         try:
             if not raw.scielo_domain or not raw.publisher_id:
                 raise plumber.UnmetPrecondition()
-        except:
+        except Exception:
             raise plumber.UnmetPrecondition()
 
     @plumber.precondition(precond)
@@ -1128,17 +1128,68 @@ class XMLClosePipe(plumber.Pipe):
 
 class XMLProgramRelatedItemPipe(plumber.Pipe):
     RELATIONS_NAMESPACE = 'http://www.crossref.org/relations.xsd'
-    RELATION_TYPES = {
+
+    # Relações derivadas do atributo `related-article-type` do
+    # <related-article> (vocabulário SciELO/JATS, o mesmo da tabela do manual
+    # de marcação). Cada valor mapeia para (elemento_crossref, relationship-type).
+    #
+    # Os valores "commentary" e "letter" se repetem na especificação SciELO e
+    # são desambiguados pelo `document_type` do documento CORRENTE (valores de
+    # choices.article_types do xylose). Quando o corrente é um comentário
+    # ("article-commentary") a relação é isCommentOn; caso contrário trata-se de
+    # uma resposta/réplica e a relação é isReplyTo (chave ``None`` como padrão).
+    RELATED_ARTICLE_TYPE_RELATIONS = {
         'commentary-article': ('inter_work_relation', 'isCommentOn'),
         'reply': ('inter_work_relation', 'isReplyTo'),
         'reviewed-article': ('inter_work_relation', 'isReviewOf'),
         'reviewer-report': ('inter_work_relation', 'hasReview'),
         'preprint': ('intra_work_relation', 'hasPreprint'),
-        'article-commentary': ('inter_work_relation', 'isCommentOn'),
-        'letter': ('inter_work_relation', 'isReplyTo'),
-        'book-review': ('inter_work_relation', 'isReviewOf'),
-        'editorial': ('inter_work_relation', 'isCommentOn'),
+        'commentary': {
+            'article-commentary': ('inter_work_relation', 'isCommentOn'),
+            None: ('inter_work_relation', 'isReplyTo'),
+        },
+        'letter': {
+            'article-commentary': ('inter_work_relation', 'isCommentOn'),
+            None: ('inter_work_relation', 'isReplyTo'),
+        },
     }
+
+    # Valores de `related-article-type` sem relação equivalente no
+    # relations.xsd do Crossref (errata, retratação, adendo e expressão de
+    # preocupação). Ficam explicitamente sem mapeamento e são ignorados.
+    UNSUPPORTED_RELATED_ARTICLE_TYPES = frozenset({
+        'corrected-article',
+        'correction-forward',
+        'retracted-article',
+        'retraction-forward',
+        'partial-retraction',
+        'addended-article',
+        'addendum',
+        'expression-of-concern',
+        'object-of-concern',
+    })
+
+    @classmethod
+    def _resolve_relation(cls, related_article, current_document_type):
+        """Resolve (elemento, relationship-type) do Crossref para um documento
+        relacionado.
+
+        Usa o `related-article-type` do documento relacionado como fonte
+        primária e o `current_document_type` do documento corrente para desambiguar
+        os valores que se repetem na especificação SciELO (ex.: "letter" e
+        "commentary").
+        """
+        related_article_type = related_article.get('related_article_type')
+
+        if related_article_type in cls.UNSUPPORTED_RELATED_ARTICLE_TYPES:
+            return None
+
+        relation = cls.RELATED_ARTICLE_TYPE_RELATIONS.get(related_article_type)
+        if isinstance(relation, dict):
+            relation = relation.get(
+                current_document_type, relation.get(None))
+
+        return relation
 
     def transform(self, data):
         raw, xml = data
@@ -1222,29 +1273,27 @@ class XMLProgramRelatedItemPipe(plumber.Pipe):
     def _transform_related_articles(self, data):
         raw, xml = data
         related_articles = getattr(raw, 'related_documents', None)
-        if callable(related_articles):
-            related_articles = related_articles()
 
         if not related_articles:
             return data
+
+        current_document_type = getattr(raw, 'document_type', None)
 
         journal_article_node = xml.find('.//journal_article')
         program_node = self._get_or_create_program(journal_article_node)
 
         for related_article in related_articles:
-            document_type = related_article.get('document_type')
-            if not document_type:
-                document_type = getattr(raw, 'document_type', None)
-            relation_data = self.RELATION_TYPES.get(document_type)
-            identifier = related_article.get('identifier')
+            relation_data = self._resolve_relation(
+                related_article, current_document_type)
+            identifier = related_article.get('id')
             if not relation_data or not identifier:
                 continue
 
             program_node.append(self._create_related_item(
-                relation_data[0],
-                relation_data[1],
-                identifier,
-                related_article.get('identifier_type') or 'doi',
+                relation_element=relation_data[0],
+                relationship_type=relation_data[1],
+                identifier=identifier,
+                identifier_type=related_article.get('ext_link_type') or 'doi',
             ))
 
         return data

--- a/articlemeta/export_crossref.py
+++ b/articlemeta/export_crossref.py
@@ -1135,39 +1135,29 @@ class XMLProgramRelatedItemPipe(plumber.Pipe):
     #
     # Os valores "commentary" e "letter" se repetem na especificação SciELO e
     # são desambiguados pelo `document_type` do documento CORRENTE (valores de
-    # choices.article_types do xylose). Quando o corrente é um comentário
-    # ("article-commentary") a relação é isCommentOn; caso contrário trata-se de
-    # uma resposta/réplica e a relação é isReplyTo (chave ``None`` como padrão).
+    # choices.article_types do xylose):
+    #   - article-commentary → isCommentOn
+    #   - research-article   → hasComment (apenas para "commentary")
+    #   - demais             → isReplyTo (chave ``None``)
+    # Tipos ausentes deste dicionário não geram related_item.
     RELATED_ARTICLE_TYPE_RELATIONS = {
         'commentary-article': ('inter_work_relation', 'isCommentOn'),
         'reply': ('inter_work_relation', 'isReplyTo'),
         'reviewed-article': ('inter_work_relation', 'isReviewOf'),
+        'peer-reviewed-material': ('inter_work_relation', 'isReviewOf'),
         'reviewer-report': ('inter_work_relation', 'hasReview'),
         'preprint': ('intra_work_relation', 'hasPreprint'),
         'commentary': {
             'article-commentary': ('inter_work_relation', 'isCommentOn'),
+            'research-article': ('inter_work_relation', 'hasComment'),
             None: ('inter_work_relation', 'isReplyTo'),
         },
         'letter': {
             'article-commentary': ('inter_work_relation', 'isCommentOn'),
             None: ('inter_work_relation', 'isReplyTo'),
         },
+        'article-commentary': ('inter_work_relation', 'isCommentOn'),
     }
-
-    # Valores de `related-article-type` sem relação equivalente no
-    # relations.xsd do Crossref (errata, retratação, adendo e expressão de
-    # preocupação). Ficam explicitamente sem mapeamento e são ignorados.
-    UNSUPPORTED_RELATED_ARTICLE_TYPES = frozenset({
-        'corrected-article',
-        'correction-forward',
-        'retracted-article',
-        'retraction-forward',
-        'partial-retraction',
-        'addended-article',
-        'addendum',
-        'expression-of-concern',
-        'object-of-concern',
-    })
 
     @classmethod
     def _resolve_relation(cls, related_article, current_document_type):
@@ -1180,11 +1170,13 @@ class XMLProgramRelatedItemPipe(plumber.Pipe):
         "commentary").
         """
         related_article_type = related_article.get('related_article_type')
-
-        if related_article_type in cls.UNSUPPORTED_RELATED_ARTICLE_TYPES:
+        if not related_article_type:
             return None
 
         relation = cls.RELATED_ARTICLE_TYPE_RELATIONS.get(related_article_type)
+        if relation is None:
+            return None
+
         if isinstance(relation, dict):
             relation = relation.get(
                 current_document_type, relation.get(None))
@@ -1248,7 +1240,7 @@ class XMLProgramRelatedItemPipe(plumber.Pipe):
 
             program_node.append(self._create_related_item(
                 'intra_work_relation',
-                'isTranslationOf',
+                'hasTranslation',
                 doi,
                 description=translated_titles.get(lang),
             ))
@@ -1262,7 +1254,7 @@ class XMLProgramRelatedItemPipe(plumber.Pipe):
             program_node = self._create_program()
             program_node.append(self._create_related_item(
                 'intra_work_relation',
-                'hasTranslation',
+                'isTranslationOf',
                 raw.doi,
                 description=raw.original_title(),
             ))
@@ -1280,7 +1272,6 @@ class XMLProgramRelatedItemPipe(plumber.Pipe):
         current_document_type = getattr(raw, 'document_type', None)
 
         journal_article_node = xml.find('.//journal_article')
-        program_node = self._get_or_create_program(journal_article_node)
 
         for related_article in related_articles:
             relation_data = self._resolve_relation(
@@ -1289,6 +1280,7 @@ class XMLProgramRelatedItemPipe(plumber.Pipe):
             if not relation_data or not identifier:
                 continue
 
+            program_node = self._get_or_create_program(journal_article_node)
             program_node.append(self._create_related_item(
                 relation_element=relation_data[0],
                 relationship_type=relation_data[1],

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ thriftpy2==0.5.0
 urllib3==1.26.19
 venusian==1.1.0
 WebOb==1.8.7
--e git+https://github.com/scieloorg/xylose.git@1.35.13#egg=xylose
+-e git+https://github.com/scieloorg/xylose.git@1.35.15#egg=xylose
 zope.deprecation==4.3.0
 zope.interface==6.1
 crossrefapi==1.3.0

--- a/tests/test_export_crossref.py
+++ b/tests/test_export_crossref.py
@@ -1343,25 +1343,25 @@ class ExportCrossRef_MultiLingueDoc_with_MultipleDOI_Tests(unittest.TestCase):
              "Epidemiological profile of patients on"
              " renal replacement therapy in Brazil, 2000-2004",
              0,
-             "isTranslationOf",
+             "hasTranslation",
              ),
             ('10.1590/ID.es',
              "Perfil epidemiológico de los pacientes en terapia"
              " renal substitutiva en Brasil, 2000-2004",
              1,
-             "isTranslationOf",
+             "hasTranslation",
              ),
             ('10.1590/S0034-89102010000400007',
              "Perfil epidemiológico dos pacientes em terapia"
              " renal substitutiva no Brasil, 2000-2004",
              2,
-             "hasTranslation",
+             "isTranslationOf",
              ),
             ('10.1590/S0034-89102010000400007',
              "Perfil epidemiológico dos pacientes em terapia"
              " renal substitutiva no Brasil, 2000-2004",
              3,
-             "hasTranslation",
+             "isTranslationOf",
              ),
         ]
         self.assertEqual(
@@ -1471,13 +1471,13 @@ class ExportCrossRef_MultiLingueDoc_with_MultipleDOI_Tests(unittest.TestCase):
         # "letter" e "commentary" se repetem na especificação SciELO e são
         # desambiguados pelo document_type do documento corrente (valores de
         # choices.article_types). "article-commentary" (código 'co') vira
-        # isCommentOn; qualquer outro document_type é tratado como resposta e
-        # vira isReplyTo.
+        # isCommentOn; "research-article" (código 'ct') vira hasComment; demais
+        # tipos caem no padrão isReplyTo.
         cases = [
             # (código v71 do corrente, related_article_type, relationship-type)
             ('co', 'commentary', 'isCommentOn'),
             ('le', 'commentary', 'isReplyTo'),
-            ('ct', 'commentary', 'isReplyTo'),
+            ('ct', 'commentary', 'hasComment'),
             ('co', 'letter', 'isCommentOn'),
             ('le', 'letter', 'isReplyTo'),
             ('ct', 'letter', 'isReplyTo'),
@@ -1513,9 +1513,8 @@ class ExportCrossRef_MultiLingueDoc_with_MultipleDOI_Tests(unittest.TestCase):
                 self.assertEqual(
                     expected, relation.attrib.get('relationship-type'))
 
-    def test_related_item_ignores_unsupported_related_article_types(self):
-        # Errata, retratação, adendo e expressão de preocupação não possuem
-        # relação equivalente no Crossref e devem ser ignorados.
+    def test_related_item_ignores_unmapped_related_article_types(self):
+        # Tipos ausentes de RELATED_ARTICLE_TYPE_RELATIONS não geram related_item.
         related_documents = [
             {'id': '10.1590/a', 'related_article_type': 'corrected-article'},
             {'id': '10.1590/b', 'related_article_type': 'retracted-article'},
@@ -2201,13 +2200,13 @@ class ExportCrossRef_MultiLingueDoc_with_DOI_pt_es_Tests(unittest.TestCase):
              "Perfil epidemiológico de los pacientes en terapia"
              " renal substitutiva en Brasil, 2000-2004",
              0,
-             "isTranslationOf",
+             "hasTranslation",
              ),
             ('10.1590/S0034-89102010000400007',
              "Perfil epidemiológico dos pacientes em terapia"
              " renal substitutiva no Brasil, 2000-2004",
              1,
-             "hasTranslation",
+             "isTranslationOf",
              ),
         ]
         self.assertEqual(

--- a/tests/test_export_crossref.py
+++ b/tests/test_export_crossref.py
@@ -1437,39 +1437,34 @@ class ExportCrossRef_MultiLingueDoc_with_MultipleDOI_Tests(unittest.TestCase):
         expected_content = [
             (
                 '10.1590/commentary',
-                'Documento comentado',
                 'inter_work_relation',
                 'isCommentOn',
             ),
             (
                 '10.1590/reply',
-                'Documento respondido',
                 'inter_work_relation',
                 'isReplyTo',
             ),
             (
                 '10.1590/reviewed',
-                'Documento revisado por pares',
                 'inter_work_relation',
                 'isReviewOf',
             ),
             (
                 '10.1590/preprint',
-                'Preprint relacionado ao artigo',
                 'intra_work_relation',
                 'hasPreprint',
             ),
         ]
         for related_item, content in zip(related_items[2:], expected_content):
             with self.subTest(identifier=content[0]):
-                self.assertEqual(
-                    content[1], related_item.findtext('description'))
-                relation = related_item.find(content[2])
+                self.assertIsNone(related_item.find('description'))
+                relation = related_item.find(content[1])
                 self.assertEqual(content[0], relation.text)
                 self.assertEqual(
                     'doi', relation.attrib.get('identifier-type'))
                 self.assertEqual(
-                    content[3],
+                    content[2],
                     relation.attrib.get('relationship-type'))
 
     def test_related_item_for_article_type_mappings(self):
@@ -1550,7 +1545,7 @@ class ExportCrossRef_MultiLingueDoc_with_MultipleDOI_Tests(unittest.TestCase):
             ['pt', 'en', 'es'])
 
         data = [self._article, xmlcrossref]
-        xmlcrossref = export_crossref.XMLProgramRelatedItemPipe()      
+        xmlcrossref = export_crossref.XMLProgramRelatedItemPipe()
         with patch.object(
                 Article,
                 'related_documents',
@@ -1569,7 +1564,8 @@ class ExportCrossRef_MultiLingueDoc_with_MultipleDOI_Tests(unittest.TestCase):
             len(xml.findall(
                 './/program/related_item/intra_work_relation'
             ))
-        )        
+        )
+
     def test_related_item_includes_has_preprint_relation(self):
         self._article.data['article']['v241'] = [
             {

--- a/tests/test_export_crossref.py
+++ b/tests/test_export_crossref.py
@@ -708,20 +708,20 @@ class ExportCrossRef_one_DOI_only_Tests(unittest.TestCase):
     def test_related_articles_validating_against_schema(self):
         related_documents = [
             {
-                'identifier': '10.1590/S2237-96222025v34e20240180.a',
-                'document_type': 'reviewed-article',
-                'identifier_type': 'doi',
+                'id': '10.1590/S2237-96222025v34e20240180.a',
+                'related_article_type': 'reviewed-article',
+                'ext_link_type': 'doi',
             },
             {
-                'identifier': '10.1590/S2237-96222025v34e20240180.b',
-                'document_type': 'commentary-article',
-                'identifier_type': 'doi',
+                'id': '10.1590/S2237-96222025v34e20240180.b',
+                'related_article_type': 'commentary-article',
+                'ext_link_type': 'doi',
             },
         ]
         with patch.object(
                 Article,
                 'related_documents',
-                create=True,
+                new_callable=PropertyMock,
                 return_value=related_documents):
             xml = export.Export(self._raw_json).pipeline_crossref()
 
@@ -1391,29 +1391,29 @@ class ExportCrossRef_MultiLingueDoc_with_MultipleDOI_Tests(unittest.TestCase):
             ['pt', 'en', 'es'])
         related_documents = [
             {
-                'identifier': '10.1590/commentary',
-                'document_type': 'commentary-article',
-                'identifier_type': 'doi',
+                'id': '10.1590/commentary',
+                'related_article_type': 'commentary-article',
+                'ext_link_type': 'doi',
             },
             {
-                'identifier': '10.1590/reply',
-                'document_type': 'reply',
-                'identifier_type': 'doi',
+                'id': '10.1590/reply',
+                'related_article_type': 'reply',
+                'ext_link_type': 'doi',
             },
             {
-                'identifier': '10.1590/reviewed',
-                'document_type': 'reviewed-article',
-                'identifier_type': 'doi',
+                'id': '10.1590/reviewed',
+                'related_article_type': 'reviewed-article',
+                'ext_link_type': 'doi',
             },
             {
-                'identifier': '10.1590/preprint',
-                'document_type': 'preprint',
-                'identifier_type': 'doi',
+                'id': '10.1590/preprint',
+                'related_article_type': 'preprint',
+                'ext_link_type': 'doi',
             },
             {
-                'identifier': '10.1590/corrected',
-                'document_type': 'corrected-article',
-                'identifier_type': 'doi',
+                'id': '10.1590/corrected',
+                'related_article_type': 'corrected-article',
+                'ext_link_type': 'doi',
             },
         ]
 
@@ -1467,78 +1467,98 @@ class ExportCrossRef_MultiLingueDoc_with_MultipleDOI_Tests(unittest.TestCase):
                     content[2],
                     relation.attrib.get('relationship-type'))
 
-    def test_related_item_for_article_type_mappings(self):
-        xmlcrossref = create_xmlcrossref_with_n_journal_article_element(['pt'])
-        related_documents = [
-            {
-                'identifier': '10.1590/commented',
-                'document_type': 'article-commentary',
-                'identifier_type': 'doi',
-            },
-            {
-                'identifier': '10.1590/replied',
-                'document_type': 'letter',
-                'identifier_type': 'doi',
-            },
-            {
-                'identifier': '10.1590/reviewed-book',
-                'document_type': 'book-review',
-                'identifier_type': 'doi',
-            },
-            {
-                'identifier': '10.1590/editorial-target',
-                'document_type': 'editorial',
-                'identifier_type': 'doi',
-            },
+    def test_related_item_disambiguates_repeated_related_article_types(self):
+        # "letter" e "commentary" se repetem na especificação SciELO e são
+        # desambiguados pelo document_type do documento corrente (valores de
+        # choices.article_types). "article-commentary" (código 'co') vira
+        # isCommentOn; qualquer outro document_type é tratado como resposta e
+        # vira isReplyTo.
+        cases = [
+            # (código v71 do corrente, related_article_type, relationship-type)
+            ('co', 'commentary', 'isCommentOn'),
+            ('le', 'commentary', 'isReplyTo'),
+            ('ct', 'commentary', 'isReplyTo'),
+            ('co', 'letter', 'isCommentOn'),
+            ('le', 'letter', 'isReplyTo'),
+            ('ct', 'letter', 'isReplyTo'),
         ]
+        for type_code, related_article_type, expected in cases:
+            with self.subTest(
+                    type_code=type_code,
+                    related_article_type=related_article_type):
+                article = _get_article({'v71': [{'_': type_code}]})
+                related_documents = [
+                    {
+                        'id': '10.1590/target',
+                        'related_article_type': related_article_type,
+                        'ext_link_type': 'doi',
+                    },
+                ]
+                xmlcrossref = create_xmlcrossref_with_n_journal_article_element(
+                    ['pt'])
+
+                data = [article, xmlcrossref]
+                pipe = export_crossref.XMLProgramRelatedItemPipe()
+                with patch.object(
+                        Article,
+                        'related_documents',
+                        new_callable=PropertyMock,
+                        return_value=related_documents):
+                    raw, xml = pipe.transform(data)
+
+                relation = xml.find(
+                    './/program/related_item/inter_work_relation')
+                self.assertIsNotNone(relation)
+                self.assertEqual('10.1590/target', relation.text)
+                self.assertEqual(
+                    expected, relation.attrib.get('relationship-type'))
+
+    def test_related_item_ignores_unsupported_related_article_types(self):
+        # Errata, retratação, adendo e expressão de preocupação não possuem
+        # relação equivalente no Crossref e devem ser ignorados.
+        related_documents = [
+            {'id': '10.1590/a', 'related_article_type': 'corrected-article'},
+            {'id': '10.1590/b', 'related_article_type': 'retracted-article'},
+            {'id': '10.1590/c', 'related_article_type': 'partial-retraction'},
+            {'id': '10.1590/d', 'related_article_type': 'addendum'},
+            {'id': '10.1590/e', 'related_article_type': 'expression-of-concern'},
+        ]
+        xmlcrossref = create_xmlcrossref_with_n_journal_article_element(['pt'])
 
         data = [self._article, xmlcrossref]
-        xmlcrossref = export_crossref.XMLProgramRelatedItemPipe()
+        pipe = export_crossref.XMLProgramRelatedItemPipe()
         with patch.object(
                 Article,
                 'related_documents',
                 new_callable=PropertyMock,
                 return_value=related_documents):
-            raw, xml = xmlcrossref.transform(data)
+            raw, xml = pipe.transform(data)
 
-        related_items = xml.findall('.//program/related_item/inter_work_relation')
-        expected_content = [
-            ('10.1590/commented', 'isCommentOn'),
-            ('10.1590/replied', 'isReplyTo'),
-            ('10.1590/reviewed-book', 'isReviewOf'),
-            ('10.1590/editorial-target', 'isCommentOn'),
-        ]
-        self.assertEqual(len(expected_content), len(related_items))
-        for relation, content in zip(related_items, expected_content):
-            with self.subTest(identifier=content[0]):
-                self.assertEqual(content[0], relation.text)
-                self.assertEqual(
-                    content[1],
-                    relation.attrib.get('relationship-type'))
+        self.assertEqual(
+            0,
+            len(xml.findall('.//program/related_item/inter_work_relation')))
 
-    def test_related_item_uses_article_document_type_when_missing(self):
-        article = _get_article({'v71': [{'_': 'le'}]})
+    def test_related_item_ignores_missing_related_article_type(self):
         related_documents = [
             {
-                'identifier': '10.1590/target',
-                'identifier_type': 'doi',
+                'id': '10.1590/target',
+                'ext_link_type': 'doi',
             },
         ]
         xmlcrossref = create_xmlcrossref_with_n_journal_article_element(['pt'])
 
-        data = [article, xmlcrossref]
-        xmlcrossref = export_crossref.XMLProgramRelatedItemPipe()
+        data = [self._article, xmlcrossref]
+        pipe = export_crossref.XMLProgramRelatedItemPipe()
         with patch.object(
                 Article,
                 'related_documents',
                 new_callable=PropertyMock,
                 return_value=related_documents):
-            raw, xml = xmlcrossref.transform(data)
+            raw, xml = pipe.transform(data)
 
-        relation = xml.find(
-            './/program/related_item/inter_work_relation')
-        self.assertEqual('10.1590/target', relation.text)
-        self.assertEqual('isReplyTo', relation.attrib.get('relationship-type'))
+        self.assertEqual(
+            0,
+            len(xml.findall('.//program/related_item/inter_work_relation')))
 
     def test_related_item_without_related_documents(self):
         xmlcrossref = create_xmlcrossref_with_n_journal_article_element(

--- a/tests/test_export_crossref.py
+++ b/tests/test_export_crossref.py
@@ -3,7 +3,7 @@ import unittest
 import json
 import os
 import io
-from unittest.mock import patch
+from unittest.mock import patch, PropertyMock
 
 from lxml import etree as ET
 
@@ -1373,7 +1373,7 @@ class ExportCrossRef_MultiLingueDoc_with_MultipleDOI_Tests(unittest.TestCase):
     def test_related_item_for_supported_related_articles(self):
         xmlcrossref = create_xmlcrossref_with_n_journal_article_element(
             ['pt', 'en', 'es'])
-        self._article.related_documents = lambda: [
+        related_documents = [
             {
                 'identifier': '10.1590/commentary',
                 'document_type': 'commentary-article',
@@ -1403,7 +1403,12 @@ class ExportCrossRef_MultiLingueDoc_with_MultipleDOI_Tests(unittest.TestCase):
 
         data = [self._article, xmlcrossref]
         xmlcrossref = export_crossref.XMLProgramRelatedItemPipe()
-        raw, xml = xmlcrossref.transform(data)
+        with patch.object(
+                Article,
+                'related_documents',
+                new_callable=PropertyMock,
+                return_value=related_documents):
+            raw, xml = xmlcrossref.transform(data)
 
         journal_articles = xml.findall('.//journal_article')
         original_program = journal_articles[0].find('program')
@@ -1453,7 +1458,7 @@ class ExportCrossRef_MultiLingueDoc_with_MultipleDOI_Tests(unittest.TestCase):
 
     def test_related_item_for_article_type_mappings(self):
         xmlcrossref = create_xmlcrossref_with_n_journal_article_element(['pt'])
-        self._article.related_documents = lambda: [
+        related_documents = [
             {
                 'identifier': '10.1590/commented',
                 'document_type': 'article-commentary',
@@ -1478,7 +1483,12 @@ class ExportCrossRef_MultiLingueDoc_with_MultipleDOI_Tests(unittest.TestCase):
 
         data = [self._article, xmlcrossref]
         xmlcrossref = export_crossref.XMLProgramRelatedItemPipe()
-        raw, xml = xmlcrossref.transform(data)
+        with patch.object(
+                Article,
+                'related_documents',
+                new_callable=PropertyMock,
+                return_value=related_documents):
+            raw, xml = xmlcrossref.transform(data)
 
         related_items = xml.findall('.//program/related_item/inter_work_relation')
         expected_content = [
@@ -1497,7 +1507,7 @@ class ExportCrossRef_MultiLingueDoc_with_MultipleDOI_Tests(unittest.TestCase):
 
     def test_related_item_uses_article_document_type_when_missing(self):
         article = _get_article({'v71': [{'_': 'le'}]})
-        article.related_documents = lambda: [
+        related_documents = [
             {
                 'identifier': '10.1590/target',
                 'identifier_type': 'doi',
@@ -1507,7 +1517,12 @@ class ExportCrossRef_MultiLingueDoc_with_MultipleDOI_Tests(unittest.TestCase):
 
         data = [article, xmlcrossref]
         xmlcrossref = export_crossref.XMLProgramRelatedItemPipe()
-        raw, xml = xmlcrossref.transform(data)
+        with patch.object(
+                Article,
+                'related_documents',
+                new_callable=PropertyMock,
+                return_value=related_documents):
+            raw, xml = xmlcrossref.transform(data)
 
         relation = xml.find(
             './/program/related_item/inter_work_relation')
@@ -1517,11 +1532,15 @@ class ExportCrossRef_MultiLingueDoc_with_MultipleDOI_Tests(unittest.TestCase):
     def test_related_item_without_related_documents(self):
         xmlcrossref = create_xmlcrossref_with_n_journal_article_element(
             ['pt', 'en', 'es'])
-        self._article.related_documents = lambda: []
 
         data = [self._article, xmlcrossref]
         xmlcrossref = export_crossref.XMLProgramRelatedItemPipe()
-        raw, xml = xmlcrossref.transform(data)
+        with patch.object(
+                Article,
+                'related_documents',
+                new_callable=PropertyMock,
+                return_value=[]):
+            raw, xml = xmlcrossref.transform(data)
 
         self.assertEqual(
             0,

--- a/tests/test_export_crossref.py
+++ b/tests/test_export_crossref.py
@@ -3,6 +3,7 @@ import unittest
 import json
 import os
 import io
+from unittest.mock import patch
 
 from lxml import etree as ET
 
@@ -689,6 +690,48 @@ class ExportCrossRef_one_DOI_only_Tests(unittest.TestCase):
         self.assertTrue(schema.validate(xmlio))
         self.assertEqual(None, schema.assertValid(xmlio))
 
+    def test_related_articles_validating_against_schema(self):
+        related_documents = [
+            {
+                'identifier': '10.1590/S2237-96222025v34e20240180.a',
+                'document_type': 'reviewed-article',
+                'identifier_type': 'doi',
+            },
+            {
+                'identifier': '10.1590/S2237-96222025v34e20240180.b',
+                'document_type': 'commentary-article',
+                'identifier_type': 'doi',
+            },
+        ]
+        with patch.object(
+                Article,
+                'related_documents',
+                create=True,
+                return_value=related_documents):
+            xml = export.Export(self._raw_json).pipeline_crossref()
+
+        xmlio = ET.parse(io.BytesIO(xml))
+        schema_path = (
+            os.path.dirname(__file__) +
+            '/xsd/scielo_crossref/crossref4.4.0.xsd'
+        )
+        with open(schema_path) as fp:
+            schema = ET.XMLSchema(ET.parse(fp))
+
+        schema.assertValid(xmlio)
+        relations = xmlio.findall(
+            './/{http://www.crossref.org/relations.xsd}'
+            'inter_work_relation'
+        )
+        self.assertEqual(2, len(relations))
+        self.assertEqual(
+            ['isReviewOf', 'isCommentOn'],
+            [
+                relation.attrib.get('relationship-type')
+                for relation in relations
+            ]
+        )
+
     def test_journal_article_should_contain_item_number_with_elocation_id(self):
         xmlcrossref = ET.Element("doi_batch")
         publisher_item = ET.Element("publisher_item")
@@ -1326,6 +1369,172 @@ class ExportCrossRef_MultiLingueDoc_with_MultipleDOI_Tests(unittest.TestCase):
                 self.assertEqual(
                     content[3],
                     intra_work_relation.attrib.get('relationship-type'))
+
+    def test_related_item_for_supported_related_articles(self):
+        xmlcrossref = create_xmlcrossref_with_n_journal_article_element(
+            ['pt', 'en', 'es'])
+        self._article.related_documents = lambda: [
+            {
+                'identifier': '10.1590/commentary',
+                'document_type': 'commentary-article',
+                'identifier_type': 'doi',
+            },
+            {
+                'identifier': '10.1590/reply',
+                'document_type': 'reply',
+                'identifier_type': 'doi',
+            },
+            {
+                'identifier': '10.1590/reviewed',
+                'document_type': 'reviewed-article',
+                'identifier_type': 'doi',
+            },
+            {
+                'identifier': '10.1590/preprint',
+                'document_type': 'preprint',
+                'identifier_type': 'doi',
+            },
+            {
+                'identifier': '10.1590/corrected',
+                'document_type': 'corrected-article',
+                'identifier_type': 'doi',
+            },
+        ]
+
+        data = [self._article, xmlcrossref]
+        xmlcrossref = export_crossref.XMLProgramRelatedItemPipe()
+        raw, xml = xmlcrossref.transform(data)
+
+        journal_articles = xml.findall('.//journal_article')
+        original_program = journal_articles[0].find('program')
+        related_items = original_program.findall('./related_item')
+
+        self.assertEqual(3, len(xml.findall('.//program')))
+        self.assertEqual(
+            6, len(related_items))
+
+        expected_content = [
+            (
+                '10.1590/commentary',
+                'Documento comentado',
+                'inter_work_relation',
+                'isCommentOn',
+            ),
+            (
+                '10.1590/reply',
+                'Documento respondido',
+                'inter_work_relation',
+                'isReplyTo',
+            ),
+            (
+                '10.1590/reviewed',
+                'Documento revisado por pares',
+                'inter_work_relation',
+                'isReviewOf',
+            ),
+            (
+                '10.1590/preprint',
+                'Preprint relacionado ao artigo',
+                'intra_work_relation',
+                'hasPreprint',
+            ),
+        ]
+        for related_item, content in zip(related_items[2:], expected_content):
+            with self.subTest(identifier=content[0]):
+                self.assertEqual(
+                    content[1], related_item.findtext('description'))
+                relation = related_item.find(content[2])
+                self.assertEqual(content[0], relation.text)
+                self.assertEqual(
+                    'doi', relation.attrib.get('identifier-type'))
+                self.assertEqual(
+                    content[3],
+                    relation.attrib.get('relationship-type'))
+
+    def test_related_item_for_article_type_mappings(self):
+        xmlcrossref = create_xmlcrossref_with_n_journal_article_element(['pt'])
+        self._article.related_documents = lambda: [
+            {
+                'identifier': '10.1590/commented',
+                'document_type': 'article-commentary',
+                'identifier_type': 'doi',
+            },
+            {
+                'identifier': '10.1590/replied',
+                'document_type': 'letter',
+                'identifier_type': 'doi',
+            },
+            {
+                'identifier': '10.1590/reviewed-book',
+                'document_type': 'book-review',
+                'identifier_type': 'doi',
+            },
+            {
+                'identifier': '10.1590/editorial-target',
+                'document_type': 'editorial',
+                'identifier_type': 'doi',
+            },
+        ]
+
+        data = [self._article, xmlcrossref]
+        xmlcrossref = export_crossref.XMLProgramRelatedItemPipe()
+        raw, xml = xmlcrossref.transform(data)
+
+        related_items = xml.findall('.//program/related_item/inter_work_relation')
+        expected_content = [
+            ('10.1590/commented', 'isCommentOn'),
+            ('10.1590/replied', 'isReplyTo'),
+            ('10.1590/reviewed-book', 'isReviewOf'),
+            ('10.1590/editorial-target', 'isCommentOn'),
+        ]
+        self.assertEqual(len(expected_content), len(related_items))
+        for relation, content in zip(related_items, expected_content):
+            with self.subTest(identifier=content[0]):
+                self.assertEqual(content[0], relation.text)
+                self.assertEqual(
+                    content[1],
+                    relation.attrib.get('relationship-type'))
+
+    def test_related_item_uses_article_document_type_when_missing(self):
+        article = _get_article({'v71': [{'_': 'le'}]})
+        article.related_documents = lambda: [
+            {
+                'identifier': '10.1590/target',
+                'identifier_type': 'doi',
+            },
+        ]
+        xmlcrossref = create_xmlcrossref_with_n_journal_article_element(['pt'])
+
+        data = [article, xmlcrossref]
+        xmlcrossref = export_crossref.XMLProgramRelatedItemPipe()
+        raw, xml = xmlcrossref.transform(data)
+
+        relation = xml.find(
+            './/program/related_item/inter_work_relation')
+        self.assertEqual('10.1590/target', relation.text)
+        self.assertEqual('isReplyTo', relation.attrib.get('relationship-type'))
+
+    def test_related_item_without_related_documents(self):
+        xmlcrossref = create_xmlcrossref_with_n_journal_article_element(
+            ['pt', 'en', 'es'])
+        self._article.related_documents = lambda: []
+
+        data = [self._article, xmlcrossref]
+        xmlcrossref = export_crossref.XMLProgramRelatedItemPipe()
+        raw, xml = xmlcrossref.transform(data)
+
+        self.assertEqual(
+            0,
+            len(xml.findall(
+                './/program/related_item/inter_work_relation'
+            ))
+        )
+        self.assertEqual(
+            4,
+            len(xml.findall(
+                './/program/related_item/intra_work_relation'
+            ))
+        )
 
     def test_collection_for_multilingue_document(self):
         xmlcrossref = create_xmlcrossref_with_n_journal_article_element(

--- a/tests/test_export_crossref.py
+++ b/tests/test_export_crossref.py
@@ -1406,6 +1406,16 @@ class ExportCrossRef_MultiLingueDoc_with_MultipleDOI_Tests(unittest.TestCase):
                 'ext_link_type': 'doi',
             },
             {
+                'id': '10.1590/peer-reviewed',
+                'related_article_type': 'peer-reviewed-material',
+                'ext_link_type': 'doi',
+            },
+            {
+                'id': '10.1590/reviewer-report',
+                'related_article_type': 'reviewer-report',
+                'ext_link_type': 'doi',
+            },
+            {
                 'id': '10.1590/preprint',
                 'related_article_type': 'preprint',
                 'ext_link_type': 'doi',
@@ -1432,7 +1442,7 @@ class ExportCrossRef_MultiLingueDoc_with_MultipleDOI_Tests(unittest.TestCase):
 
         self.assertEqual(3, len(xml.findall('.//program')))
         self.assertEqual(
-            6, len(related_items))
+            8, len(related_items))
 
         expected_content = [
             (
@@ -1451,6 +1461,16 @@ class ExportCrossRef_MultiLingueDoc_with_MultipleDOI_Tests(unittest.TestCase):
                 'isReviewOf',
             ),
             (
+                '10.1590/peer-reviewed',
+                'inter_work_relation',
+                'isReviewOf',
+            ),
+            (
+                '10.1590/reviewer-report',
+                'inter_work_relation',
+                'hasReview',
+            ),
+            (
                 '10.1590/preprint',
                 'intra_work_relation',
                 'hasPreprint',
@@ -1467,20 +1487,81 @@ class ExportCrossRef_MultiLingueDoc_with_MultipleDOI_Tests(unittest.TestCase):
                     content[2],
                     relation.attrib.get('relationship-type'))
 
+    def test_related_item_for_peer_reviewed_material_is_review_of(self):
+        # peer-reviewed-material aponta para o material revisado → isReviewOf
+        related_documents = [
+            {
+                'id': '10.1590/reviewed-material',
+                'related_article_type': 'peer-reviewed-material',
+                'ext_link_type': 'doi',
+            },
+        ]
+        xmlcrossref = create_xmlcrossref_with_n_journal_article_element(['pt'])
+        article = _get_article({
+            'v337': [{
+                'l': 'pt',
+                'd': '10.1590/S0034-89102010000400007',
+            }],
+        })
+
+        data = [article, xmlcrossref]
+        pipe = export_crossref.XMLProgramRelatedItemPipe()
+        with patch.object(
+                Article,
+                'related_documents',
+                new_callable=PropertyMock,
+                return_value=related_documents):
+            raw, xml = pipe.transform(data)
+
+        relation = xml.find('.//program/related_item/inter_work_relation')
+        self.assertIsNotNone(relation)
+        self.assertEqual('10.1590/reviewed-material', relation.text)
+        self.assertEqual('doi', relation.attrib.get('identifier-type'))
+        self.assertEqual('isReviewOf', relation.attrib.get('relationship-type'))
+        self.assertEqual(1, len(xml.findall('.//program/related_item')))
+
+    def test_related_item_for_reviewer_report_has_review(self):
+        # reviewer-report é o outro lado da relação de peer review → hasReview
+        related_documents = [
+            {
+                'id': '10.1590/reviewer-report',
+                'related_article_type': 'reviewer-report',
+                'ext_link_type': 'doi',
+            },
+        ]
+        xmlcrossref = create_xmlcrossref_with_n_journal_article_element(['pt'])
+        article = _get_article({
+            'v337': [{
+                'l': 'pt',
+                'd': '10.1590/S0034-89102010000400007',
+            }],
+        })
+
+        data = [article, xmlcrossref]
+        pipe = export_crossref.XMLProgramRelatedItemPipe()
+        with patch.object(
+                Article,
+                'related_documents',
+                new_callable=PropertyMock,
+                return_value=related_documents):
+            raw, xml = pipe.transform(data)
+
+        relation = xml.find('.//program/related_item/inter_work_relation')
+        self.assertIsNotNone(relation)
+        self.assertEqual('10.1590/reviewer-report', relation.text)
+        self.assertEqual('doi', relation.attrib.get('identifier-type'))
+        self.assertEqual('hasReview', relation.attrib.get('relationship-type'))
+        self.assertEqual(1, len(xml.findall('.//program/related_item')))
+
     def test_related_item_disambiguates_repeated_related_article_types(self):
         # "letter" e "commentary" se repetem na especificação SciELO e são
-        # desambiguados pelo document_type do documento corrente (valores de
-        # choices.article_types). "article-commentary" (código 'co') vira
-        # isCommentOn; "research-article" (código 'ct') vira hasComment; demais
-        # tipos caem no padrão isReplyTo.
+        # desambiguados pelo document_type do documento corrente. Somente
+        # combinações conhecidas são emitidas.
         cases = [
             # (código v71 do corrente, related_article_type, relationship-type)
             ('co', 'commentary', 'isCommentOn'),
-            ('le', 'commentary', 'isReplyTo'),
             ('ct', 'commentary', 'hasComment'),
             ('co', 'letter', 'isCommentOn'),
-            ('le', 'letter', 'isReplyTo'),
-            ('ct', 'letter', 'isReplyTo'),
         ]
         for type_code, related_article_type, expected in cases:
             with self.subTest(
@@ -1513,8 +1594,97 @@ class ExportCrossRef_MultiLingueDoc_with_MultipleDOI_Tests(unittest.TestCase):
                 self.assertEqual(
                     expected, relation.attrib.get('relationship-type'))
 
+    def test_related_item_when_main_document_is_reply(self):
+        # Documento principal do tipo reply + related commentary/letter →
+        # isReplyTo. xylose não mapeia v71 para "reply", então document_type
+        # é mockado.
+        cases = ['commentary', 'letter']
+        for related_article_type in cases:
+            with self.subTest(related_article_type=related_article_type):
+                article = _get_article({
+                    'v337': [{
+                        'l': 'pt',
+                        'd': '10.1590/S0034-89102010000400007',
+                    }],
+                })
+                related_documents = [
+                    {
+                        'id': '10.1590/target',
+                        'related_article_type': related_article_type,
+                        'ext_link_type': 'doi',
+                    },
+                ]
+                xmlcrossref = create_xmlcrossref_with_n_journal_article_element(
+                    ['pt'])
+
+                data = [article, xmlcrossref]
+                pipe = export_crossref.XMLProgramRelatedItemPipe()
+                with patch.object(
+                        Article,
+                        'document_type',
+                        new_callable=PropertyMock,
+                        return_value='reply'), \
+                        patch.object(
+                            Article,
+                            'related_documents',
+                            new_callable=PropertyMock,
+                            return_value=related_documents):
+                    raw, xml = pipe.transform(data)
+
+                relation = xml.find(
+                    './/program/related_item/inter_work_relation')
+                self.assertIsNotNone(relation)
+                self.assertEqual('10.1590/target', relation.text)
+                self.assertEqual(
+                    'isReplyTo', relation.attrib.get('relationship-type'))
+
+    def test_related_item_ignores_unknown_commentary_letter_combinations(self):
+        # Combinações de commentary/letter com document_type não documentado
+        # não geram related_item até haver casos reais.
+        cases = [
+            ('le', 'commentary'),
+            ('le', 'letter'),
+            ('ct', 'letter'),
+            ('ra', 'commentary'),
+            ('ed', 'letter'),
+        ]
+        for type_code, related_article_type in cases:
+            with self.subTest(
+                    type_code=type_code,
+                    related_article_type=related_article_type):
+                article = _get_article({
+                    'v71': [{'_': type_code}],
+                    'v337': [{
+                        'l': 'pt',
+                        'd': '10.1590/S0034-89102010000400007',
+                    }],
+                })
+                related_documents = [
+                    {
+                        'id': '10.1590/target',
+                        'related_article_type': related_article_type,
+                        'ext_link_type': 'doi',
+                    },
+                ]
+                xmlcrossref = create_xmlcrossref_with_n_journal_article_element(
+                    ['pt'])
+
+                data = [article, xmlcrossref]
+                pipe = export_crossref.XMLProgramRelatedItemPipe()
+                with patch.object(
+                        Article,
+                        'related_documents',
+                        new_callable=PropertyMock,
+                        return_value=related_documents):
+                    raw, xml = pipe.transform(data)
+
+                self.assertIsNone(
+                    xml.find('.//program/related_item/inter_work_relation'))
+                self.assertIsNone(xml.find('.//program'))
+
     def test_related_item_ignores_unmapped_related_article_types(self):
-        # Tipos ausentes de RELATED_ARTICLE_TYPE_RELATIONS não geram related_item.
+        # Tipos ausentes de RELATED_ARTICLE_TYPE_RELATIONS não geram related_item
+        # nem um <program/> vazio.
         related_documents = [
             {'id': '10.1590/a', 'related_article_type': 'corrected-article'},
             {'id': '10.1590/b', 'related_article_type': 'retracted-article'},
@@ -1523,8 +1693,14 @@ class ExportCrossRef_MultiLingueDoc_with_MultipleDOI_Tests(unittest.TestCase):
             {'id': '10.1590/e', 'related_article_type': 'expression-of-concern'},
         ]
         xmlcrossref = create_xmlcrossref_with_n_journal_article_element(['pt'])
+        article = _get_article({
+            'v337': [{
+                'l': 'pt',
+                'd': '10.1590/S0034-89102010000400007',
+            }],
+        })
 
-        data = [self._article, xmlcrossref]
+        data = [article, xmlcrossref]
         pipe = export_crossref.XMLProgramRelatedItemPipe()
         with patch.object(
                 Article,
@@ -1536,6 +1712,7 @@ class ExportCrossRef_MultiLingueDoc_with_MultipleDOI_Tests(unittest.TestCase):
         self.assertEqual(
             0,
             len(xml.findall('.//program/related_item/inter_work_relation')))
+        self.assertIsNone(xml.find('.//program'))
 
     def test_related_item_ignores_missing_related_article_type(self):
         related_documents = [
@@ -1545,8 +1722,14 @@ class ExportCrossRef_MultiLingueDoc_with_MultipleDOI_Tests(unittest.TestCase):
             },
         ]
         xmlcrossref = create_xmlcrossref_with_n_journal_article_element(['pt'])
+        article = _get_article({
+            'v337': [{
+                'l': 'pt',
+                'd': '10.1590/S0034-89102010000400007',
+            }],
+        })
 
-        data = [self._article, xmlcrossref]
+        data = [article, xmlcrossref]
         pipe = export_crossref.XMLProgramRelatedItemPipe()
         with patch.object(
                 Article,
@@ -1558,6 +1741,7 @@ class ExportCrossRef_MultiLingueDoc_with_MultipleDOI_Tests(unittest.TestCase):
         self.assertEqual(
             0,
             len(xml.findall('.//program/related_item/inter_work_relation')))
+        self.assertIsNone(xml.find('.//program'))
 
     def test_related_item_without_related_documents(self):
         xmlcrossref = create_xmlcrossref_with_n_journal_article_element(


### PR DESCRIPTION
#### O que esse PR faz?

Expande o `XMLProgramRelatedItemPipe` para exportar documentos relacionados no depósito Crossref, consumindo a property `related_documents` do xylose (campo legado `v241`).

As principais mudanças são:

- Mapeamento de tipos SPS e `article_type` para `relationship-type` válidos em `relations.xsd` (`hasReview`, `isCommentOn`, `isReplyTo`, `isReviewOf`, `hasPreprint`, etc.).
- Refatoração da criação dos nós `<program>`, `<related_item>`, `<description>` e relações `inter_work`/`intra_work`.
- Manutenção das relações de tradução existentes (`isTranslationOf` / `hasTranslation`).
- Novos testes com validação contra o XSD Crossref 4.4.0.

Tipos editoriais sem correspondência em `relations.xsd` (ex.: `corrected-article`, `retracted-article`) são ignorados.

#### Onde a revisão poderia começar?

Comece por `articlemeta/export_crossref.py`, na classe `XMLProgramRelatedItemPipe` — especialmente `RELATION_TYPES`, `_transform_related_articles` e os helpers `_create_program`, `_get_or_create_program` e `_create_related_item`.

Em seguida, veja os testes em `tests/test_export_crossref.py`:
- `test_related_articles_validating_against_schema`
- `test_related_item_for_supported_related_articles`
- `test_related_item_for_article_type_mappings`

#### Como este poderia ser testado manualmente?

1. Instale o xylose com a property `related_documents` (dependência do PR scieloorg/xylose#207).
2. Baixe um artigo com campo `v241`, por exemplo:

```bash
curl -s "https://articlemeta.scielo.org/api/v1/article/?collection=scl&code=S2237-96222025000100200" -o /tmp/article.json
```

3. Gere o XML Crossref localmente:

```bash
python -c "
import json
from articlemeta.export import Export
article = json.load(open('/tmp/article.json'))
open('crossref.xml', 'wb').write(Export(article).pipeline_crossref())
"
```

4. Verifique no XML gerado o bloco `<program xmlns="http://www.crossref.org/relations.xsd">` com `<inter_work_relation relationship-type="hasReview">` para pareceres (`reviewer-report`).
5. Rode os testes automatizados:

```bash
python -m unittest tests.test_export_crossref
```

#### Algum cenário de contexto que queira dar?

Este PR depende da property `related_documents` no xylose, que abstrai o campo `v241` e retorna dicionários com `identifier`, `document_type`, `identifier_type` e `label`.

A distinção entre `inter_work_relation` e `intra_work_relation` segue o `relations.xsd`: relações entre obras distintas (comentários, pareceres, resenhas) usam `inter_work`; variantes da mesma obra (traduções, preprints) usam `intra_work`.

### Screenshots

N/A

#### Quais são tickets relevantes?
https://github.com/scieloorg/articles_meta/issues/329
https://github.com/scieloorg/xylose/pull/207

### Referências

- Crossref Relations Schema (`relations.xsd`): https://www.crossref.org/schema/relations.xsd
- Crossref schema 4.4.0 (validação em `tests/xsd/scielo_crossref/crossref4.4.0.xsd`)
- https://docs.google.com/document/d/1GTv4Inc2LS_AXY-ToHT3HmO66UT0VAHWJNOIqzBNSgA/edit?tab=t.0#heading=h.2upcpyuv6r4o
- https://articlemeta.scielo.org/api/v1/article/?collection=scl&code=S0104-11692026000101005&format=xmlcrossref
- https://www.crossref.org/documentation/schema-library/markup-guide-metadata-segments/relationships/
- https://gitlab.com/crossref/schema/-/tree/master/best-practice-examples?ref_type=heads
- https://gitlab.com/crossref/schema/-/blob/master/best-practice-examples/journal_article_translation_5.4.0.xml?ref_type=heads

---

## Segurança da informação (NSI.04)

**Este PR manipula dados sensíveis ou pessoais (LGPD)?**
- [ ] Sim — descreva os controles de proteção aplicados (criptografia, mascaramento, anonimização, etc.):
- [x] Não

**Este PR altera autenticação, autorização, controle de acesso ou gerenciamento de sessão?**
- [ ] Sim — descreva o que mudou e por quê:
- [x] Não

**Este PR introduz, atualiza ou remove dependências de terceiros?**
- [ ] Sim — as novas dependências foram verificadas no SBOM/Trivy sem vulnerabilidades críticas/altas em aberto?
  - [ ] Verificado e aprovado
  - [ ] Pendente / vulnerabilidade aceita com justificativa:
- [x] Não

**Este PR foi validado pelo pipeline de segurança (SonarQube / Trivy)?**
- [ ] Sim — link do job:
- [x] Não aplicável a este PR (justifique): alterações localizadas em código Python/Django e traduções; sem mudanças em infra/dependências.

**Este PR concatena, monta ou executa comandos SQL, HTML ou JavaScript a partir de entrada externa?**
- [ ] Sim — confirme que há sanitização/parametrização (prepared statements, escaping, etc.):
- [x] Não

**Este PR expõe novos endpoints, telas ou serviços?**
- [x] Sim — HTTPS obrigatório está garantido e o acesso segue o princípio de menor privilégio?
  - As novas telas são páginas do Wagtail ModelAdmin, acessíveis apenas a usuários autenticados e com permissões do Django.
- [ ] Não

**Algum segredo, senha, chave ou token está sendo adicionado ao código-fonte?**
- [x] Não, nenhum segredo foi commitado
- [ ] Sim (bloquear merge e corrigir antes de prosseguir)